### PR TITLE
add support for direct use of slice of struct pointers for MarshalMany AND support to unmarshal attributes to ptr types

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -13,6 +13,60 @@ type BadModel struct {
 	Id int `jsonapi:"primary"`
 }
 
+type Foo struct {
+	Id       string   `jsonapi:"primary,foos"`
+	Name     *string  `jsonapi:"attr,name"`
+	IsActive *bool    `jsonapi:"attr,is-active"`
+	IntVal   *int     `jsonapi:"attr,int-val"`
+	FloatVal *float32 `jsonapi:"attr,float-val"`
+}
+
+func TestUnmarshalToStructWithPointerAttr(t *testing.T) {
+	out := new(Foo)
+	in := map[string]interface{}{
+		"name":      "The name",
+		"is-active": true,
+		"int-val":   8,
+		"float-val": 1.1,
+	}
+	if err := UnmarshalPayload(sampleFooPayload(in), out); err != nil {
+		t.Fatalf("Error unmarshalling to Foo")
+	}
+	if *out.Name != "The name" {
+		t.Fatalf("Error unmarshalling to string ptr")
+	}
+	if *out.IsActive != true {
+		t.Fatalf("Error unmarshalling to bool ptr")
+	}
+	if *out.IntVal != 8 {
+		t.Fatalf("Error unmarshalling to int ptr")
+	}
+	if *out.FloatVal != 1.1 {
+		t.Fatalf("Error unmarshalling to float ptr")
+	}
+}
+
+func TestUnmarshalToStructWithPointerAttr_AbsentVal(t *testing.T) {
+	out := new(Foo)
+	in := map[string]interface{}{
+		"name":      "The name",
+		"is-active": true,
+	}
+	if err := UnmarshalPayload(sampleFooPayload(in), out); err != nil {
+		t.Fatalf("Error unmarshalling to Foo")
+	}
+	// these were present in the payload -- expect val to be not nil
+	if out.Name == nil || out.IsActive == nil {
+		t.Fatalf("Error unmarshalling; expected ptr to be not nil")
+	}
+
+	// these were absent in the payload -- expect val to be nil
+	if out.IntVal != nil || out.FloatVal != nil {
+		t.Fatalf("Error unmarshalling; expected ptr to be nil")
+	}
+
+}
+
 func TestMalformedTag(t *testing.T) {
 	out := new(BadModel)
 	err := UnmarshalPayload(samplePayload(), out)
@@ -296,6 +350,22 @@ func samplePayloadWithId() io.Reader {
 				"title":      "New blog",
 				"view_count": 1000,
 			},
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+
+	json.NewEncoder(out).Encode(payload)
+
+	return out
+}
+
+func sampleFooPayload(m map[string]interface{}) io.Reader {
+	payload := &OnePayload{
+		Data: &Node{
+			Id:         "2",
+			Type:       "foos",
+			Attributes: m,
 		},
 	}
 

--- a/response_test.go
+++ b/response_test.go
@@ -236,6 +236,29 @@ func TestMarshalMany(t *testing.T) {
 	}
 }
 
+func TestMarshalMany_WithSliceOfStructPointers(t *testing.T) {
+	var data []*Blog
+	for len(data) < 2 {
+		data = append(data, testBlog())
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalManyPayload(out, data); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(ManyPayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	d := resp.Data
+
+	if len(d) != 2 {
+		t.Fatalf("data should have two elements")
+	}
+}
+
 func testBlog() *Blog {
 	return &Blog{
 		Id:        5,

--- a/runtime.go
+++ b/runtime.go
@@ -56,7 +56,7 @@ func (r *Runtime) MarshalOnePayload(w io.Writer, model interface{}) error {
 	})
 }
 
-func (r *Runtime) MarshalManyPayload(w io.Writer, models []interface{}) error {
+func (r *Runtime) MarshalManyPayload(w io.Writer, models interface{}) error {
 	return r.instrumentCall(MarshalStart, MarshalStop, func() error {
 		return MarshalManyPayload(w, models)
 	})


### PR DESCRIPTION
@shwoodard, I made a change to the the "models" type for MarshalMany from []interface{} to interface{}.  Its a small change that properly "boxes" so that you can pass the function either a slice of interface{} (as it expects currently) or slice of struct pointers.  Its backwards compatible and I added a check that only "unboxes" if the val type is a slice.  

stephan