### PR TITLE
Handle type errors during unmarshalNode routine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,54 @@ func (post Post) JSONAPIRelationshipLinks(relation string) *map[string]interface
 }
 ```
 
+### Errors
+This package also implements support for JSON API compatible `errors` payloads using the following types.
+
+#### `MarshalErrors`
+```go
+MarshalErrors(w io.Writer, errs []*ErrorObject) error
+```
+
+Writes a JSON API response using the given `[]error`.
+
+#### `ErrorsPayload`
+```go
+type ErrorsPayload struct {
+	Errors []*ErrorObject `json:"errors"`
+}
+```
+
+ErrorsPayload is a serializer struct for representing a valid JSON API errors payload.
+
+#### `ErrorObject`
+```go
+type ErrorObject struct { ... }
+
+// Error implements the `Error` interface.
+func (e *ErrorObject) Error() string {
+	return fmt.Sprintf("Error: %s %s\n", e.Title, e.Detail)
+}
+```
+
+ErrorObject is an `Error` implementation as well as an implementation of the JSON API error object.
+
+The main idea behind this struct is that you can use it directly in your code as an error type and pass it directly to `MarshalErrors` to get a valid JSON API errors payload.
+
+##### Errors Example Code
+```go
+// An error has come up in your code, so set an appropriate status, and serialize the error.
+if err := validate(&myStructToValidate); err != nil {
+	context.SetStatusCode(http.StatusBadRequest) // Or however you need to set a status.
+	jsonapi.MarshalErrors(w, []*ErrorObject{{
+		Title: "Validation Error",
+		Detail: "Given request body was invalid.",
+		Status: "400",
+		Meta: map[string]interface{}{"field": "some_field", "error": "bad type", "expected": "string", "received": "float64"},
+	}})
+	return
+}
+```
+
 ## Testing
 
 ### `MarshalOnePayloadEmbedded`

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,55 @@
+package jsonapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// MarshalErrors writes a JSON API response using the given `[]error`.
+//
+// For more information on JSON API error payloads, see the spec here:
+// http://jsonapi.org/format/#document-top-level
+// and here: http://jsonapi.org/format/#error-objects.
+func MarshalErrors(w io.Writer, errorObjects []*ErrorObject) error {
+	if err := json.NewEncoder(w).Encode(&ErrorsPayload{Errors: errorObjects}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ErrorsPayload is a serializer struct for representing a valid JSON API errors payload.
+type ErrorsPayload struct {
+	Errors []*ErrorObject `json:"errors"`
+}
+
+// ErrorObject is an `Error` implementation as well as an implementation of the JSON API error object.
+//
+// The main idea behind this struct is that you can use it directly in your code as an error type
+// and pass it directly to `MarshalErrors` to get a valid JSON API errors payload.
+// For more information on Golang errors, see: https://golang.org/pkg/errors/
+// For more information on the JSON API spec's error objects, see: http://jsonapi.org/format/#error-objects
+type ErrorObject struct {
+	// ID is a unique identifier for this particular occurrence of a problem.
+	ID string `json:"id,omitempty"`
+
+	// Title is a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization.
+	Title string `json:"title,omitempty"`
+
+	// Detail is a human-readable explanation specific to this occurrence of the problem. Like title, this field’s value can be localized.
+	Detail string `json:"detail,omitempty"`
+
+	// Status is the HTTP status code applicable to this problem, expressed as a string value.
+	Status string `json:"status,omitempty"`
+
+	// Code is an application-specific error code, expressed as a string value.
+	Code string `json:"code,omitempty"`
+
+	// Meta is an object containing non-standard meta-information about the error.
+	Meta *map[string]interface{} `json:"meta,omitempty"`
+}
+
+// Error implements the `Error` interface.
+func (e *ErrorObject) Error() string {
+	return fmt.Sprintf("Error: %s %s\n", e.Title, e.Detail)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,52 @@
+package jsonapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestErrorObjectWritesExpectedErrorMessage(t *testing.T) {
+	err := &ErrorObject{Title: "Title test.", Detail: "Detail test."}
+	var input error = err
+
+	output := input.Error()
+
+	if output != fmt.Sprintf("Error: %s %s\n", err.Title, err.Detail) {
+		t.Fatal("Unexpected output.")
+	}
+}
+
+func TestMarshalErrorsWritesTheExpectedPayload(t *testing.T) {
+	var marshalErrorsTableTasts = []struct {
+		In  []*ErrorObject
+		Out map[string]interface{}
+	}{
+		{ // This tests that given fields are turned into the appropriate JSON representation.
+			In: []*ErrorObject{{ID: "0", Title: "Test title.", Detail: "Test detail", Status: "400", Code: "E1100"}},
+			Out: map[string]interface{}{"errors": []interface{}{
+				map[string]interface{}{"id": "0", "title": "Test title.", "detail": "Test detail", "status": "400", "code": "E1100"},
+			}},
+		},
+		{ // This tests that the `Meta` field is serialized properly.
+			In: []*ErrorObject{{Title: "Test title.", Detail: "Test detail", Meta: &map[string]interface{}{"key": "val"}}},
+			Out: map[string]interface{}{"errors": []interface{}{
+				map[string]interface{}{"title": "Test title.", "detail": "Test detail", "meta": map[string]interface{}{"key": "val"}},
+			}},
+		},
+	}
+	for _, testRow := range marshalErrorsTableTasts {
+		buffer, output := bytes.NewBuffer(nil), map[string]interface{}{}
+		var writer io.Writer = buffer
+
+		_ = MarshalErrors(writer, testRow.In)
+		json.Unmarshal(buffer.Bytes(), &output)
+
+		if !reflect.DeepEqual(output, testRow.Out) {
+			t.Fatalf("Expected: \n%#v \nto equal: \n%#v", output, testRow.Out)
+		}
+	}
+}


### PR DESCRIPTION
Closes #37.
