### PR TITLE
Add support to nullify relationship; http://jsonapi.org/format/#docum…

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -184,6 +184,74 @@ func TestUnmarshalRelationships(t *testing.T) {
 	}
 }
 
+func TestUnmarshalNullRelationship(t *testing.T) {
+	sample := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "posts",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"body":  "Hello",
+				"title": "World",
+			},
+			"relationships": map[string]interface{}{
+				"latest_comment": map[string]interface{}{
+					"data": nil, //set data to nil/null
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := bytes.NewReader(data)
+	out := new(Post)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.LatestComment != nil {
+		t.Fatalf("Latest Comment was not set to nil")
+	}
+}
+
+func TestUnmarshalNullRelationshipInSlice(t *testing.T) {
+	sample := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "posts",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"body":  "Hello",
+				"title": "World",
+			},
+			"relationships": map[string]interface{}{
+				"comments": map[string]interface{}{
+					"data": []interface{}{
+						nil, //set data to nil/null
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	in := bytes.NewReader(data)
+	out := new(Post)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(out.Comments) != 0 {
+		t.Fatalf("Wrong number of comments; Comments should be empty")
+	}
+}
+
 func TestUnmarshalNestedRelationships(t *testing.T) {
 	out, err := unmarshalSamplePayload()
 	if err != nil {


### PR DESCRIPTION
Hey @aren55555, @shwoodard,
I was running into an unmarshal runtime issue when Ember set a null relationship.  Looking at this: http://jsonapi.org/format/#document-resource-object-relationships, it looks like Ember's default is setting up the request correctly (example below).  This patch is to support the below scenario where we're either saying 'program-mgr' has no relationship on a POST or nulling the existing 'program-mgr' relationship on a PATCH.  

Can you guys review the jsonapi spec, and include in master if you think the interpretation is correct?

Thanks,
stephan

```
{
  "data": {
    "attributes": {
      "name": "name",
      "status": ""
    },
    "relationships": {
      "account-mgr": {
        "data": {
          "type": "users",
          "id": "2"
        }
      },      
      "program-mgr": {
        "data": null
      }      
    },
    "type": "companies"
  }
}

```
