### PR TITLE
Add support for iso8601 struct tag argument

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -45,11 +45,16 @@ value arguments are comma separated.  The first argument must be, "primary", and
 the second must be the name that should appear in the "type" field for all data
 objects that represent this type of model.
 
-Value, attr: "attr,<key name in attributes hash>"
+Value, attr: "attr,<key name in attributes hash>[,<extra arguments>]"
 
 These fields' values should end up in the "attribute" hash for a record.  The first
 argument must be, "attr', and the second should be the name for the key to display in
 the the "attributes" hash for that record.
+
+The following extra arguments are also supported:
+
+"omitempty": excludes the fields value from the "attribute" hash.
+"iso8601": uses the ISO8601 timestamp format when serialising or deserialising the time.Time value.
 
 Value, relation: "relation,<key name in relationships hash>"
 

--- a/response.go
+++ b/response.go
@@ -24,6 +24,8 @@ var (
 	ErrExpectedSlice = errors.New("models should be a slice of struct pointers")
 )
 
+const iso8601TimeFormat = "2006-01-02T15:04:05Z"
+
 // MarshalOnePayload writes a jsonapi response with one, with related records
 // sideloaded, into "included" array. This method encodes a response for a
 // single record only. Hence, data will be a single record rather than an array
@@ -236,10 +238,17 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 				node.ClientID = clientID
 			}
 		} else if annotation == "attr" {
-			var omitEmpty bool
+			var omitEmpty, iso8601 bool
 
 			if len(args) > 2 {
-				omitEmpty = args[2] == "omitempty"
+				for _, arg := range args[2:] {
+					switch arg {
+					case "omitempty":
+						omitEmpty = true
+					case "iso8601":
+						iso8601 = true
+					}
+				}
 			}
 
 			if node.Attributes == nil {
@@ -253,7 +262,11 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 					continue
 				}
 
-				node.Attributes[args[1]] = t.Unix()
+				if iso8601 {
+					node.Attributes[args[1]] = t.UTC().Format(iso8601TimeFormat)
+				} else {
+					node.Attributes[args[1]] = t.Unix()
+				}
 			} else if fieldValue.Type() == reflect.TypeOf(new(time.Time)) {
 				// A time pointer may be nil
 				if fieldValue.IsNil() {
@@ -269,7 +282,11 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 						continue
 					}
 
-					node.Attributes[args[1]] = tm.Unix()
+					if iso8601 {
+						node.Attributes[args[1]] = tm.UTC().Format(iso8601TimeFormat)
+					} else {
+						node.Attributes[args[1]] = tm.Unix()
+					}
 				}
 			} else {
 				// Dealing with a fieldValue that is not a time


### PR DESCRIPTION
Currently only unix timestamps are supported for serialising time.Time objects. The JSON.API specification doesn't make a specific requirement on time serialisation format, though it does make a recommendation for using ISO8601.

This adds support for an additional struct tag argument `iso8601` which controls serialisation and deserialisation using the ISO8601 timestamp format.

If the `iso8601` tag argument is not included then the existing unix timestamp format will be used.

``` go
type Blog struct {
	ID            int       `jsonapi:"primary,blogs"`
	Title         string    `jsonapi:"attr,title"`
	Posts         []*Post   `jsonapi:"relation,posts"`
	CurrentPost   *Post     `jsonapi:"relation,current_post"`
	CurrentPostID int       `jsonapi:"attr,current_post_id"`
	CreatedAt     time.Time `jsonapi:"attr,created_at,iso8601"`
	ViewCount     int       `jsonapi:"attr,view_count"`
}
```

Tests for the serialisation and deserialisation are included.