### PR TITLE
Added initial support for meta data with marshal many

### DIFF
--- a/node.go
+++ b/node.go
@@ -13,9 +13,10 @@ type OnePayload struct {
 // ManyPayload is used to represent a generic JSON API payload where many
 // resources (Nodes) were included in an [] in the "data" key
 type ManyPayload struct {
-	Data     []*Node            `json:"data"`
-	Included []*Node            `json:"included,omitempty"`
-	Links    *map[string]string `json:"links,omitempty"`
+	Data     []*Node                 `json:"data"`
+	Included []*Node                 `json:"included,omitempty"`
+	Links    *map[string]string      `json:"links,omitempty"`
+	Meta     *map[string]interface{} `json:"meta,omitempty"`
 }
 
 // Node is used to represent a generic JSON API Resource

--- a/node.go
+++ b/node.go
@@ -5,9 +5,10 @@ const clientIDAnnotation = "client-id"
 // OnePayload is used to represent a generic JSON API payload where a single
 // resource (Node) was included as an {} in the "data" key
 type OnePayload struct {
-	Data     *Node              `json:"data"`
-	Included []*Node            `json:"included,omitempty"`
-	Links    *map[string]string `json:"links,omitempty"`
+	Data     *Node                   `json:"data"`
+	Included []*Node                 `json:"included,omitempty"`
+	Links    *map[string]string      `json:"links,omitempty"`
+	Meta     *map[string]interface{} `json:"meta,omitempty"`
 }
 
 // ManyPayload is used to represent a generic JSON API payload where many

--- a/response_test.go
+++ b/response_test.go
@@ -321,6 +321,82 @@ func TestMarshalMany(t *testing.T) {
 	}
 }
 
+func TestMarshalMany_WithMeta(t *testing.T) {
+	type Meta struct {
+		TotalPages int `jsonapi:"total_pages"`
+	}
+	meta := &Meta{
+		TotalPages: 10,
+	}
+
+	data := []interface{}{
+		&Blog{
+			ID:        5,
+			Title:     "Title 1",
+			CreatedAt: time.Now(),
+			Posts: []*Post{
+				&Post{
+					ID:    1,
+					Title: "Foo",
+					Body:  "Bar",
+				},
+				&Post{
+					ID:    2,
+					Title: "Fuubar",
+					Body:  "Bas",
+				},
+			},
+			CurrentPost: &Post{
+				ID:    1,
+				Title: "Foo",
+				Body:  "Bar",
+			},
+		},
+		&Blog{
+			ID:        6,
+			Title:     "Title 2",
+			CreatedAt: time.Now(),
+			Posts: []*Post{
+				&Post{
+					ID:    3,
+					Title: "Foo",
+					Body:  "Bar",
+				},
+				&Post{
+					ID:    4,
+					Title: "Fuubar",
+					Body:  "Bas",
+				},
+			},
+			CurrentPost: &Post{
+				ID:    4,
+				Title: "Foo",
+				Body:  "Bar",
+			},
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalManyPayloadWithMeta(out, data, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(ManyPayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	d := resp.Data
+
+	if len(d) != 2 {
+		t.Fatalf("data should have two elements")
+	}
+
+	if (*resp.Meta)["total_pages"].(float64) != 10 {
+		t.Fatalf("meta should be present")
+	}
+}
+
 func TestMarshalMany_WithSliceOfStructPointers(t *testing.T) {
 	var data []*Blog
 	for len(data) < 2 {


### PR DESCRIPTION
Hi All,

This could still do with comment clean up, doc update and some refactoring to remove duplicate code, but I just wanted to get an initial PR in to get some feedback on whether this is worth pursuing further.

This update enables the ability to render a many payload with a metadata section, specifically it enables the creation of a payload to support pagination.

Here is an example:

~~~go
type Meta struct {
  TotalPages int `jsonapi:"total_pages"`
}

meta := &Meta{
  TotalPages: 10,
}

if err := jsonapi.MarshalManyPayloadWithMeta(w, myCollection, meta); err != nil {
  // Something went wrong
}
~~~

This will render something like:

~~~json
{
  "data": [],
  "meta": { "total_pages": 10 }
}
~~~

The meta struct can be anything you like.
