### PR TITLE
Add support for 'links' via optional interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,28 +300,20 @@ func ListBlogs(w http.ResponseWriter, r *http.Request) {
 
 ### Links
 
-If you need to include [`link` objects](http://jsonapi.org/format/#document-links) along with response data, implement the `Linkable` interface for document-links, and the `RelationshipLinkable` for relationship links:
+If you need to include [link objects](http://jsonapi.org/format/#document-links) along with response data, implement the `Linkable` interface for document-links, and `RelationshipLinkable` for relationship links:
 
 ```go
-func (post Post) JSONLinks() *map[string]jsonapi.Link {
-	return &map[string]jsonapi.Link{
-		"self": {
-			Href: fmt.Sprintf("https://example.com/posts/%d", post.ID),
-		},
+func (post Post) JSONLinks() *map[string]interface{} {
+	return &map[string]interface{}{
+		"self": "href": fmt.Sprintf("https://example.com/posts/%d", post.ID),
 	}
 }
 
 // Invoked for each relationship defined on the Post struct when marshaled
-func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+func (post Post) JSONRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "comments" {
-		return &map[string]jsonapi.Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
-				// Optionally include a meta payload
-				Meta: map[string]interface{}{
-					"count": len(post.Comments),
-				},
-			},
+		return &map[string]interface{}{
+			"related": fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),				
 		}
 	}
 	return nil

--- a/README.md
+++ b/README.md
@@ -305,14 +305,14 @@ func ListBlogs(w http.ResponseWriter, r *http.Request) {
 If you need to include [link objects](http://jsonapi.org/format/#document-links) along with response data, implement the `Linkable` interface for document-links, and `RelationshipLinkable` for relationship links:
 
 ```go
-func (post Post) JSONLinks() *map[string]interface{} {
+func (post Post) JSONAPILinks() *map[string]interface{} {
 	return &map[string]interface{}{
 		"self": "href": fmt.Sprintf("https://example.com/posts/%d", post.ID),
 	}
 }
 
 // Invoked for each relationship defined on the Post struct when marshaled
-func (post Post) JSONRelationshipLinks(relation string) *map[string]interface{} {
+func (post Post) JSONAPIRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "comments" {
 		return &map[string]interface{}{
 			"related": fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),				

--- a/README.md
+++ b/README.md
@@ -298,6 +298,36 @@ func ListBlogs(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+### Links
+
+If you need to include [`link` objects](http://jsonapi.org/format/#document-links) along with response data, implement the `Linkable` interface for document-links, and the `RelationshipLinkable` for relationship links:
+
+```go
+func (post Post) JSONLinks() *map[string]jsonapi.Link {
+	return &map[string]jsonapi.Link{
+		"self": {
+			Href: fmt.Sprintf("https://example.com/posts/%d", post.ID),
+		},
+	}
+}
+
+// Invoked for each relationship defined on the Post struct when marshaled
+func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+	if relation == "comments" {
+		return &map[string]jsonapi.Link{
+			"related": {
+				Href: fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
+				// Optionally include a meta payload
+				Meta: map[string]interface{}{
+					"count": len(post.Comments),
+				},
+			},
+		}
+	}
+	return nil
+}
+```
+
 ## Testing
 
 ### `MarshalOnePayloadEmbedded`

--- a/examples/app.go
+++ b/examples/app.go
@@ -271,30 +271,21 @@ type Comment struct {
 
 // BLog Links
 
-func (blog Blog) JSONLinks() *map[string]jsonapi.Link {
-	return &map[string]jsonapi.Link{
-		"self": {
-			Href: fmt.Sprintf("https://example.com/blogs/%d", blog.ID),
-		},
+func (blog Blog) JSONLinks() *map[string]interface{} {
+	return &map[string]interface{}{
+		"self": fmt.Sprintf("https://example.com/blogs/%d", blog.ID),
 	}
 }
 
-func (blog Blog) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+func (blog Blog) JSONRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "posts" {
-		return &map[string]jsonapi.Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/blogs/%d/posts", blog.ID),
-				Meta: map[string]interface{}{
-					"count": len(blog.Posts),
-				},
-			},
+		return &map[string]interface{}{
+			"related": fmt.Sprintf("https://example.com/blogs/%d/posts", blog.ID),
 		}
 	}
 	if relation == "current_post" {
-		return &map[string]jsonapi.Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/blogs/%d/current_post", blog.ID),
-			},
+		return &map[string]interface{}{
+			"related": fmt.Sprintf("https://example.com/blogs/%d/current_post", blog.ID),
 		}
 	}
 	return nil
@@ -302,23 +293,16 @@ func (blog Blog) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link
 
 // Post Links
 
-func (post Post) JSONLinks() *map[string]jsonapi.Link {
-	return &map[string]jsonapi.Link{
-		"self": {
-			Href: fmt.Sprintf("https://example.com/posts/%d", post.ID),
-		},
+func (post Post) JSONLinks() *map[string]interface{} {
+	return &map[string]interface{}{
+		"self": fmt.Sprintf("https://example.com/posts/%d", post.ID),
 	}
 }
 
-func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+func (post Post) JSONRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "comments" {
-		return &map[string]jsonapi.Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
-				Meta: map[string]interface{}{
-					"count": len(post.Comments),
-				},
-			},
+		return &map[string]interface{}{
+			"related": fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
 		}
 	}
 	return nil
@@ -326,10 +310,8 @@ func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link
 
 // Comment Links
 
-func (comment Comment) JSONLinks() *map[string]jsonapi.Link {
-	return &map[string]jsonapi.Link{
-		"self": {
-			Href: fmt.Sprintf("https://example.com/comments/%d", comment.ID),
-		},
+func (comment Comment) JSONLinks() *map[string]interface{} {
+	return &map[string]interface{}{
+		"self": fmt.Sprintf("https://example.com/comments/%d", comment.ID),
 	}
 }

--- a/examples/app.go
+++ b/examples/app.go
@@ -268,3 +268,68 @@ type Comment struct {
 	PostID int    `jsonapi:"attr,post_id"`
 	Body   string `jsonapi:"attr,body"`
 }
+
+// BLog Links
+
+func (blog Blog) JSONLinks() *map[string]jsonapi.Link {
+	return &map[string]jsonapi.Link{
+		"self": {
+			Href: fmt.Sprintf("https://example.com/blogs/%d", blog.ID),
+		},
+	}
+}
+
+func (blog Blog) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+	if relation == "posts" {
+		return &map[string]jsonapi.Link{
+			"related": {
+				Href: fmt.Sprintf("https://example.com/blogs/%d/posts", blog.ID),
+				Meta: map[string]interface{}{
+					"count": len(blog.Posts),
+				},
+			},
+		}
+	}
+	if relation == "current_post" {
+		return &map[string]jsonapi.Link{
+			"related": {
+				Href: fmt.Sprintf("https://example.com/blogs/%d/current_post", blog.ID),
+			},
+		}
+	}
+	return nil
+}
+
+// Post Links
+
+func (post Post) JSONLinks() *map[string]jsonapi.Link {
+	return &map[string]jsonapi.Link{
+		"self": {
+			Href: fmt.Sprintf("https://example.com/posts/%d", post.ID),
+		},
+	}
+}
+
+func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
+	if relation == "comments" {
+		return &map[string]jsonapi.Link{
+			"related": {
+				Href: fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
+				Meta: map[string]interface{}{
+					"count": len(post.Comments),
+				},
+			},
+		}
+	}
+	return nil
+}
+
+// Comment Links
+
+func (comment Comment) JSONLinks() *map[string]jsonapi.Link {
+	return &map[string]jsonapi.Link{
+		"self": {
+			Href: fmt.Sprintf("https://example.com/comments/%d", comment.ID),
+		},
+	}
+}

--- a/examples/app.go
+++ b/examples/app.go
@@ -269,15 +269,14 @@ type Comment struct {
 	Body   string `jsonapi:"attr,body"`
 }
 
-// BLog Links
-
-func (blog Blog) JSONLinks() *map[string]interface{} {
+// Blog Links
+func (blog Blog) JSONAPILinks() *map[string]interface{} {
 	return &map[string]interface{}{
 		"self": fmt.Sprintf("https://example.com/blogs/%d", blog.ID),
 	}
 }
 
-func (blog Blog) JSONRelationshipLinks(relation string) *map[string]interface{} {
+func (blog Blog) JSONAPIRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "posts" {
 		return &map[string]interface{}{
 			"related": fmt.Sprintf("https://example.com/blogs/%d/posts", blog.ID),
@@ -292,14 +291,13 @@ func (blog Blog) JSONRelationshipLinks(relation string) *map[string]interface{} 
 }
 
 // Post Links
-
-func (post Post) JSONLinks() *map[string]interface{} {
+func (post Post) JSONAPILinks() *map[string]interface{} {
 	return &map[string]interface{}{
 		"self": fmt.Sprintf("https://example.com/posts/%d", post.ID),
 	}
 }
 
-func (post Post) JSONRelationshipLinks(relation string) *map[string]interface{} {
+func (post Post) JSONAPIRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "comments" {
 		return &map[string]interface{}{
 			"related": fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
@@ -309,8 +307,7 @@ func (post Post) JSONRelationshipLinks(relation string) *map[string]interface{} 
 }
 
 // Comment Links
-
-func (comment Comment) JSONLinks() *map[string]interface{} {
+func (comment Comment) JSONAPILinks() *map[string]interface{} {
 	return &map[string]interface{}{
 		"self": fmt.Sprintf("https://example.com/comments/%d", comment.ID),
 	}

--- a/examples/app.go
+++ b/examples/app.go
@@ -169,7 +169,7 @@ func testBlogForCreate(i int) *Blog {
 func testBlogsForList() []interface{} {
 	blogs := make([]interface{}, 0, 10)
 
-	for i := 0; i < 10; i += 1 {
+	for i := 0; i < 10; i++ {
 		blogs = append(blogs, testBlogForCreate(i))
 	}
 
@@ -184,13 +184,13 @@ func exerciseHandler() {
 
 	w := httptest.NewRecorder()
 
-	fmt.Println("============ start list ===========\n")
+	fmt.Println("============ start list ===========")
 	http.DefaultServeMux.ServeHTTP(w, req)
-	fmt.Println("============ stop list ===========\n")
+	fmt.Println("============ stop list ===========")
 
 	jsonReply, _ := ioutil.ReadAll(w.Body)
 
-	fmt.Println("============ jsonapi response from list ===========\n")
+	fmt.Println("============ jsonapi response from list ===========")
 	fmt.Println(string(jsonReply))
 	fmt.Println("============== end raw jsonapi from list =============")
 
@@ -201,13 +201,13 @@ func exerciseHandler() {
 
 	w = httptest.NewRecorder()
 
-	fmt.Println("============ start show ===========\n")
+	fmt.Println("============ start show ===========")
 	http.DefaultServeMux.ServeHTTP(w, req)
-	fmt.Println("============ stop show ===========\n")
+	fmt.Println("============ stop show ===========")
 
 	jsonReply, _ = ioutil.ReadAll(w.Body)
 
-	fmt.Println("\n============ jsonapi response from show ===========\n")
+	fmt.Println("\n============ jsonapi response from show ===========")
 	fmt.Println(string(jsonReply))
 	fmt.Println("============== end raw jsonapi from show =============")
 
@@ -222,14 +222,14 @@ func exerciseHandler() {
 
 	w = httptest.NewRecorder()
 
-	fmt.Println("============ start create ===========\n")
+	fmt.Println("============ start create ===========")
 	http.DefaultServeMux.ServeHTTP(w, req)
-	fmt.Println("============ stop create ===========\n")
+	fmt.Println("============ stop create ===========")
 
 	buf := bytes.NewBuffer(nil)
 	io.Copy(buf, w.Body)
 
-	fmt.Println("\n============ jsonapi response from create ===========\n")
+	fmt.Println("\n============ jsonapi response from create ===========")
 	fmt.Println(buf.String())
 	fmt.Println("============== end raw jsonapi response =============")
 
@@ -240,7 +240,7 @@ func exerciseHandler() {
 	out := bytes.NewBuffer(nil)
 	json.NewEncoder(out).Encode(responseBlog)
 
-	fmt.Println("\n================ Viola! Converted back our Blog struct =================\n")
+	fmt.Println("\n================ Viola! Converted back our Blog struct =================")
 	fmt.Printf("%s\n", out.Bytes())
 	fmt.Println("================ end marshal materialized Blog struct =================")
 }
@@ -288,27 +288,4 @@ func (blog Blog) JSONAPIRelationshipLinks(relation string) *map[string]interface
 		}
 	}
 	return nil
-}
-
-// Post Links
-func (post Post) JSONAPILinks() *map[string]interface{} {
-	return &map[string]interface{}{
-		"self": fmt.Sprintf("https://example.com/posts/%d", post.ID),
-	}
-}
-
-func (post Post) JSONAPIRelationshipLinks(relation string) *map[string]interface{} {
-	if relation == "comments" {
-		return &map[string]interface{}{
-			"related": fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
-		}
-	}
-	return nil
-}
-
-// Comment Links
-func (comment Comment) JSONAPILinks() *map[string]interface{} {
-	return &map[string]interface{}{
-		"self": fmt.Sprintf("https://example.com/comments/%d", comment.ID),
-	}
 }

--- a/node.go
+++ b/node.go
@@ -76,12 +76,12 @@ type Link struct {
 // Linkable is used to include document links in response data
 // e.g. {"self": "http://example.com/posts/1"}
 type Linkable interface {
-	JSONLinks() *Links
+	JSONAPILinks() *Links
 }
 
 // RelationshipLinkable is used to include relationship links  in response data
 // e.g. {"related": "http://example.com/posts/1/comments"}
 type RelationshipLinkable interface {
-	// JSONRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONRelationshipLinks(relation string) *Links
+	// JSONAPIRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
+	JSONAPIRelationshipLinks(relation string) *Links
 }

--- a/node.go
+++ b/node.go
@@ -7,17 +7,17 @@ const clientIDAnnotation = "client-id"
 // OnePayload is used to represent a generic JSON API payload where a single
 // resource (Node) was included as an {} in the "data" key
 type OnePayload struct {
-	Data     *Node        `json:"data"`
-	Included []*Node      `json:"included,omitempty"`
-	Links    *LinksObject `json:"links,omitempty"`
+	Data     *Node   `json:"data"`
+	Included []*Node `json:"included,omitempty"`
+	Links    *Links  `json:"links,omitempty"`
 }
 
 // ManyPayload is used to represent a generic JSON API payload where many
 // resources (Nodes) were included in an [] in the "data" key
 type ManyPayload struct {
-	Data     []*Node      `json:"data"`
-	Included []*Node      `json:"included,omitempty"`
-	Links    *LinksObject `json:"links,omitempty"`
+	Data     []*Node `json:"data"`
+	Included []*Node `json:"included,omitempty"`
+	Links    *Links  `json:"links,omitempty"`
 }
 
 // Node is used to represent a generic JSON API Resource
@@ -27,27 +27,27 @@ type Node struct {
 	ClientID      string                 `json:"client-id,omitempty"`
 	Attributes    map[string]interface{} `json:"attributes,omitempty"`
 	Relationships map[string]interface{} `json:"relationships,omitempty"`
-	Links         *LinksObject           `json:"links,omitempty"`
+	Links         *Links                 `json:"links,omitempty"`
 }
 
 // RelationshipOneNode is used to represent a generic has one JSON API relation
 type RelationshipOneNode struct {
-	Data  *Node        `json:"data"`
-	Links *LinksObject `json:"links,omitempty"`
+	Data  *Node  `json:"data"`
+	Links *Links `json:"links,omitempty"`
 }
 
 // RelationshipManyNode is used to represent a generic has many JSON API
 // relation
 type RelationshipManyNode struct {
-	Data  []*Node      `json:"data"`
-	Links *LinksObject `json:"links,omitempty"`
+	Data  []*Node `json:"data"`
+	Links *Links  `json:"links,omitempty"`
 }
 
-// LinksObject is used to represent a `links` object.
+// Links is used to represent a `links` object.
 // http://jsonapi.org/format/#document-links
-type LinksObject map[string]interface{}
+type Links map[string]interface{}
 
-func (lo *LinksObject) validate() (err error) {
+func (l *Links) validate() (err error) {
 	// Each member of a links object is a “link”. A link MUST be represented as
 	// either:
 	//  - a string containing the link’s URL.
@@ -55,15 +55,11 @@ func (lo *LinksObject) validate() (err error) {
 	//    - href: a string containing the link’s URL.
 	//    - meta: a meta object containing non-standard meta-information about the
 	//            link.
-	if lo == nil {
-		return
-	}
-
-	for k, v := range *lo {
+	for k, v := range *l {
 		_, isString := v.(string)
-		_, isLinkObject := v.(LinkObject)
+		_, isLink := v.(Link)
 
-		if !(isString || isLinkObject) {
+		if !(isString || isLink) {
 			return fmt.Errorf(
 				"The %s member of the links object was not a string or link object",
 				k,
@@ -73,8 +69,8 @@ func (lo *LinksObject) validate() (err error) {
 	return
 }
 
-// LinkObject is used to represent a member of the `links` object.
-type LinkObject struct {
+// Link is used to represent a member of the `links` object.
+type Link struct {
 	Href string                 `json:"href"`
 	Meta map[string]interface{} `json:"meta,omitempty"`
 }
@@ -82,12 +78,12 @@ type LinkObject struct {
 // Linkable is used to include document links in response data
 // e.g. {"self": "http://example.com/posts/1"}
 type Linkable interface {
-	JSONLinks() *LinksObject
+	JSONLinks() *Links
 }
 
 // RelationshipLinkable is used to include relationship links  in response data
 // e.g. {"related": "http://example.com/posts/1/comments"}
 type RelationshipLinkable interface {
 	// JSONRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONRelationshipLinks(relation string) *LinksObject
+	JSONRelationshipLinks(relation string) *Links
 }

--- a/node.go
+++ b/node.go
@@ -5,58 +5,51 @@ const clientIDAnnotation = "client-id"
 // OnePayload is used to represent a generic JSON API payload where a single
 // resource (Node) was included as an {} in the "data" key
 type OnePayload struct {
-	Data     *Node            `json:"data"`
-	Included []*Node          `json:"included,omitempty"`
-	Links    *map[string]Link `json:"links,omitempty"`
+	Data     *Node                   `json:"data"`
+	Included []*Node                 `json:"included,omitempty"`
+	Links    *map[string]interface{} `json:"links,omitempty"`
 }
 
 // ManyPayload is used to represent a generic JSON API payload where many
 // resources (Nodes) were included in an [] in the "data" key
 type ManyPayload struct {
-	Data     []*Node          `json:"data"`
-	Included []*Node          `json:"included,omitempty"`
-	Links    *map[string]Link `json:"links,omitempty"`
+	Data     []*Node                 `json:"data"`
+	Included []*Node                 `json:"included,omitempty"`
+	Links    *map[string]interface{} `json:"links,omitempty"`
 }
 
 // Node is used to represent a generic JSON API Resource
 type Node struct {
-	Type          string                 `json:"type"`
-	ID            string                 `json:"id"`
-	ClientID      string                 `json:"client-id,omitempty"`
-	Attributes    map[string]interface{} `json:"attributes,omitempty"`
-	Relationships map[string]interface{} `json:"relationships,omitempty"`
-	Links         *map[string]Link       `json:"links,omitempty"`
+	Type          string                  `json:"type"`
+	ID            string                  `json:"id"`
+	ClientID      string                  `json:"client-id,omitempty"`
+	Attributes    map[string]interface{}  `json:"attributes,omitempty"`
+	Relationships map[string]interface{}  `json:"relationships,omitempty"`
+	Links         *map[string]interface{} `json:"links,omitempty"`
 }
 
 // RelationshipOneNode is used to represent a generic has one JSON API relation
 type RelationshipOneNode struct {
-	Data  *Node            `json:"data"`
-	Links *map[string]Link `json:"links,omitempty"`
+	Data  *Node                   `json:"data"`
+	Links *map[string]interface{} `json:"links,omitempty"`
 }
 
 // RelationshipManyNode is used to represent a generic has many JSON API
 // relation
 type RelationshipManyNode struct {
-	Data  []*Node          `json:"data"`
-	Links *map[string]Link `json:"links,omitempty"`
-}
-
-// Link is used to represent a `links` object.
-// http://jsonapi.org/format/#document-links
-type Link struct {
-	Href string                 `json:"href"`
-	Meta map[string]interface{} `json:"meta,omitempty"`
+	Data  []*Node                 `json:"data"`
+	Links *map[string]interface{} `json:"links,omitempty"`
 }
 
 // Linkable is used to include document links in response data
 // e.g. {"self": "http://example.com/posts/1"}
 type Linkable interface {
-	JSONLinks() *map[string]Link
+	JSONLinks() *map[string]interface{}
 }
 
 // RelationshipLinkable is used to include relationship links  in response data
 // e.g. {"related": "http://example.com/posts/1/comments"}
 type RelationshipLinkable interface {
 	// JSONRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONRelationshipLinks(relation string) *map[string]Link
+	JSONRelationshipLinks(relation string) *map[string]interface{}
 }

--- a/node.go
+++ b/node.go
@@ -1,55 +1,93 @@
 package jsonapi
 
+import "fmt"
+
 const clientIDAnnotation = "client-id"
 
 // OnePayload is used to represent a generic JSON API payload where a single
 // resource (Node) was included as an {} in the "data" key
 type OnePayload struct {
-	Data     *Node                   `json:"data"`
-	Included []*Node                 `json:"included,omitempty"`
-	Links    *map[string]interface{} `json:"links,omitempty"`
+	Data     *Node        `json:"data"`
+	Included []*Node      `json:"included,omitempty"`
+	Links    *LinksObject `json:"links,omitempty"`
 }
 
 // ManyPayload is used to represent a generic JSON API payload where many
 // resources (Nodes) were included in an [] in the "data" key
 type ManyPayload struct {
-	Data     []*Node                 `json:"data"`
-	Included []*Node                 `json:"included,omitempty"`
-	Links    *map[string]interface{} `json:"links,omitempty"`
+	Data     []*Node      `json:"data"`
+	Included []*Node      `json:"included,omitempty"`
+	Links    *LinksObject `json:"links,omitempty"`
 }
 
 // Node is used to represent a generic JSON API Resource
 type Node struct {
-	Type          string                  `json:"type"`
-	ID            string                  `json:"id"`
-	ClientID      string                  `json:"client-id,omitempty"`
-	Attributes    map[string]interface{}  `json:"attributes,omitempty"`
-	Relationships map[string]interface{}  `json:"relationships,omitempty"`
-	Links         *map[string]interface{} `json:"links,omitempty"`
+	Type          string                 `json:"type"`
+	ID            string                 `json:"id"`
+	ClientID      string                 `json:"client-id,omitempty"`
+	Attributes    map[string]interface{} `json:"attributes,omitempty"`
+	Relationships map[string]interface{} `json:"relationships,omitempty"`
+	Links         *LinksObject           `json:"links,omitempty"`
 }
 
 // RelationshipOneNode is used to represent a generic has one JSON API relation
 type RelationshipOneNode struct {
-	Data  *Node                   `json:"data"`
-	Links *map[string]interface{} `json:"links,omitempty"`
+	Data  *Node        `json:"data"`
+	Links *LinksObject `json:"links,omitempty"`
 }
 
 // RelationshipManyNode is used to represent a generic has many JSON API
 // relation
 type RelationshipManyNode struct {
-	Data  []*Node                 `json:"data"`
-	Links *map[string]interface{} `json:"links,omitempty"`
+	Data  []*Node      `json:"data"`
+	Links *LinksObject `json:"links,omitempty"`
+}
+
+// LinksObject is used to represent a `links` object.
+// http://jsonapi.org/format/#document-links
+type LinksObject map[string]interface{}
+
+func (lo *LinksObject) validate() (err error) {
+	// Each member of a links object is a “link”. A link MUST be represented as
+	// either:
+	//  - a string containing the link’s URL.
+	//  - an object (“link object”) which can contain the following members:
+	//    - href: a string containing the link’s URL.
+	//    - meta: a meta object containing non-standard meta-information about the
+	//            link.
+	if lo == nil {
+		return
+	}
+
+	for k, v := range *lo {
+		_, isString := v.(string)
+		_, isLinkObject := v.(LinkObject)
+
+		if !(isString || isLinkObject) {
+			return fmt.Errorf(
+				"The %s member of the links object was not a string or link object",
+				k,
+			)
+		}
+	}
+	return
+}
+
+// LinkObject is used to represent a member of the `links` object.
+type LinkObject struct {
+	Href string                 `json:"href"`
+	Meta map[string]interface{} `json:"meta,omitempty"`
 }
 
 // Linkable is used to include document links in response data
 // e.g. {"self": "http://example.com/posts/1"}
 type Linkable interface {
-	JSONLinks() *map[string]interface{}
+	JSONLinks() *LinksObject
 }
 
 // RelationshipLinkable is used to include relationship links  in response data
 // e.g. {"related": "http://example.com/posts/1/comments"}
 type RelationshipLinkable interface {
 	// JSONRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONRelationshipLinks(relation string) *map[string]interface{}
+	JSONRelationshipLinks(relation string) *LinksObject
 }

--- a/node.go
+++ b/node.go
@@ -5,17 +5,17 @@ const clientIDAnnotation = "client-id"
 // OnePayload is used to represent a generic JSON API payload where a single
 // resource (Node) was included as an {} in the "data" key
 type OnePayload struct {
-	Data     *Node              `json:"data"`
-	Included []*Node            `json:"included,omitempty"`
-	Links    *map[string]string `json:"links,omitempty"`
+	Data     *Node            `json:"data"`
+	Included []*Node          `json:"included,omitempty"`
+	Links    *map[string]Link `json:"links,omitempty"`
 }
 
 // ManyPayload is used to represent a generic JSON API payload where many
 // resources (Nodes) were included in an [] in the "data" key
 type ManyPayload struct {
-	Data     []*Node            `json:"data"`
-	Included []*Node            `json:"included,omitempty"`
-	Links    *map[string]string `json:"links,omitempty"`
+	Data     []*Node          `json:"data"`
+	Included []*Node          `json:"included,omitempty"`
+	Links    *map[string]Link `json:"links,omitempty"`
 }
 
 // Node is used to represent a generic JSON API Resource
@@ -25,17 +25,38 @@ type Node struct {
 	ClientID      string                 `json:"client-id,omitempty"`
 	Attributes    map[string]interface{} `json:"attributes,omitempty"`
 	Relationships map[string]interface{} `json:"relationships,omitempty"`
+	Links         *map[string]Link       `json:"links,omitempty"`
 }
 
 // RelationshipOneNode is used to represent a generic has one JSON API relation
 type RelationshipOneNode struct {
-	Data  *Node              `json:"data"`
-	Links *map[string]string `json:"links,omitempty"`
+	Data  *Node            `json:"data"`
+	Links *map[string]Link `json:"links,omitempty"`
 }
 
 // RelationshipManyNode is used to represent a generic has many JSON API
 // relation
 type RelationshipManyNode struct {
-	Data  []*Node            `json:"data"`
-	Links *map[string]string `json:"links,omitempty"`
+	Data  []*Node          `json:"data"`
+	Links *map[string]Link `json:"links,omitempty"`
+}
+
+// Link is used to represent a `links` object.
+// http://jsonapi.org/format/#document-links
+type Link struct {
+	Href string                 `json:"href"`
+	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+// Linkable is used to include document links in response data
+// e.g. {"self": "http://example.com/posts/1"}
+type Linkable interface {
+	JSONLinks() *map[string]Link
+}
+
+// RelationshipLinkable is used to include relationship links  in response data
+// e.g. {"related": "http://example.com/posts/1/comments"}
+type RelationshipLinkable interface {
+	// JSONRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
+	JSONRelationshipLinks(relation string) *map[string]Link
 }

--- a/response.go
+++ b/response.go
@@ -345,7 +345,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 
 			var relLinks *Links
 			if linkableModel, ok := model.(RelationshipLinkable); ok {
-				relLinks = linkableModel.JSONRelationshipLinks(args[1])
+				relLinks = linkableModel.JSONAPIRelationshipLinks(args[1])
 			}
 
 			if isSlice {
@@ -420,11 +420,11 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 	}
 
 	if linkableModel, isLinkable := model.(Linkable); isLinkable {
-		jl := linkableModel.JSONLinks()
+		jl := linkableModel.JSONAPILinks()
 		if er := jl.validate(); er != nil {
 			return nil, er
 		}
-		node.Links = linkableModel.JSONLinks()
+		node.Links = linkableModel.JSONAPILinks()
 	}
 
 	return node, nil

--- a/response.go
+++ b/response.go
@@ -344,7 +344,7 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 				node.Relationships = make(map[string]interface{})
 			}
 
-			var relLinks *LinksObject
+			var relLinks *Links
 			if linkableModel, ok := model.(RelationshipLinkable); ok {
 				relLinks = linkableModel.JSONRelationshipLinks(args[1])
 			}

--- a/response.go
+++ b/response.go
@@ -336,7 +336,7 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 		} else if annotation == "relation" {
 			isSlice := fieldValue.Type().Kind() == reflect.Slice
 
-			if (!isSlice && fieldValue.IsNil()) {
+			if !isSlice && fieldValue.IsNil() {
 				continue
 			}
 
@@ -344,7 +344,7 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 				node.Relationships = make(map[string]interface{})
 			}
 
-			var relLinks *map[string]Link
+			var relLinks *map[string]interface{}
 			if linkableModel, ok := model.(RelationshipLinkable); ok {
 				relLinks = linkableModel.JSONRelationshipLinks(args[1])
 			}

--- a/response.go
+++ b/response.go
@@ -336,7 +336,7 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 		} else if annotation == "relation" {
 			isSlice := fieldValue.Type().Kind() == reflect.Slice
 
-			if (isSlice && fieldValue.Len() < 1) || (!isSlice && fieldValue.IsNil()) {
+			if (!isSlice && fieldValue.IsNil()) {
 				continue
 			}
 
@@ -350,6 +350,11 @@ func visitModelNode(model interface{}, included *map[string]*Node, sideload bool
 			}
 
 			if isSlice {
+				// Exclude the relationship if the slice is empty AND there are no defined links
+				if (fieldValue.Len() < 1) && (relLinks == nil) {
+					continue
+				}
+
 				relationship, err := visitModelNodeRelationships(
 					args[1],
 					fieldValue,

--- a/response_test.go
+++ b/response_test.go
@@ -20,29 +20,28 @@ type Blog struct {
 	ViewCount     int       `jsonapi:"attr,view_count"`
 }
 
-func (blog Blog) JSONLinks() *map[string]Link {
-	return &map[string]Link{
-		"self": {
-			Href: fmt.Sprintf("https://example.com/api/blogs/%d", blog.ID),
-		},
+func (blog Blog) JSONLinks() *map[string]interface{} {
+	return &map[string]interface{}{
+		"self": fmt.Sprintf("https://example.com/api/blogs/%d", blog.ID),
 	}
 }
 
-func (blog Blog) JSONRelationshipLinks(relation string) *map[string]Link {
+func (blog Blog) JSONRelationshipLinks(relation string) *map[string]interface{} {
 	if relation == "posts" {
-		return &map[string]Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/api/blogs/%d/posts", blog.ID),
-				Meta: map[string]interface{}{
+		return &map[string]interface{}{
+			"related": map[string]interface{}{
+				"href": fmt.Sprintf("https://example.com/api/blogs/%d/posts", blog.ID),
+				"meta": map[string]interface{}{
 					"count": len(blog.Posts),
 				},
 			},
 		}
 	}
 	if relation == "current_post" {
-		return &map[string]Link{
-			"related": {
-				Href: fmt.Sprintf("https://example.com/api/blogs/%d/current_post", blog.ID),
+		return &map[string]interface{}{
+			"self": fmt.Sprintf("https://example.com/api/posts/%s", "3"),
+			"related": map[string]interface{}{
+				"href": fmt.Sprintf("https://example.com/api/blogs/%d/current_post", blog.ID),
 			},
 		}
 	}

--- a/response_test.go
+++ b/response_test.go
@@ -20,10 +20,10 @@ type Blog struct {
 	ViewCount     int       `jsonapi:"attr,view_count"`
 }
 
-func (b *Blog) JSONLinks() *LinksObject {
-	return &LinksObject{
+func (b *Blog) JSONLinks() *Links {
+	return &Links{
 		"self": fmt.Sprintf("https://example.com/api/blogs/%d", b.ID),
-		"comments": LinkObject{
+		"comments": Link{
 			Href: fmt.Sprintf("https://example.com/api/blogs/%d/comments", b.ID),
 			Meta: map[string]interface{}{
 				"counts": map[string]uint{
@@ -35,10 +35,10 @@ func (b *Blog) JSONLinks() *LinksObject {
 	}
 }
 
-func (b *Blog) JSONRelationshipLinks(relation string) *LinksObject {
+func (b *Blog) JSONRelationshipLinks(relation string) *Links {
 	if relation == "posts" {
-		return &LinksObject{
-			"related": LinkObject{
+		return &Links{
+			"related": Link{
 				Href: fmt.Sprintf("https://example.com/api/blogs/%d/posts", b.ID),
 				Meta: map[string]interface{}{
 					"count": len(b.Posts),
@@ -47,9 +47,9 @@ func (b *Blog) JSONRelationshipLinks(relation string) *LinksObject {
 		}
 	}
 	if relation == "current_post" {
-		return &LinksObject{
+		return &Links{
 			"self": fmt.Sprintf("https://example.com/api/posts/%s", "3"),
-			"related": LinkObject{
+			"related": Link{
 				Href: fmt.Sprintf("https://example.com/api/blogs/%d/current_post", b.ID),
 			},
 		}
@@ -103,8 +103,8 @@ type BadComment struct {
 	Body string `jsonapi:"attr,body"`
 }
 
-func (bc *BadComment) JSONLinks() *LinksObject {
-	return &LinksObject{
+func (bc *BadComment) JSONLinks() *Links {
+	return &Links{
 		"self": []string{"invalid", "should error"},
 	}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -20,7 +20,7 @@ type Blog struct {
 	ViewCount     int       `jsonapi:"attr,view_count"`
 }
 
-func (b *Blog) JSONLinks() *Links {
+func (b *Blog) JSONAPILinks() *Links {
 	return &Links{
 		"self": fmt.Sprintf("https://example.com/api/blogs/%d", b.ID),
 		"comments": Link{
@@ -35,7 +35,7 @@ func (b *Blog) JSONLinks() *Links {
 	}
 }
 
-func (b *Blog) JSONRelationshipLinks(relation string) *Links {
+func (b *Blog) JSONAPIRelationshipLinks(relation string) *Links {
 	if relation == "posts" {
 		return &Links{
 			"related": Link{
@@ -224,7 +224,7 @@ type BadComment struct {
 	Body string `jsonapi:"attr,body"`
 }
 
-func (bc *BadComment) JSONLinks() *Links {
+func (bc *BadComment) JSONAPILinks() *Links {
 	return &Links{
 		"self": []string{"invalid", "should error"},
 	}


### PR DESCRIPTION
Here's a an implementation for supporting [document links](http://jsonapi.org/format/#document-links).

To include relationships links,  implement the `RelationshipLinkable` interface on a parent struct. It'll be invoked by the marshaler for each defined relationship:

```go
func (post Post) JSONRelationshipLinks(relation string) *map[string]jsonapi.Link {
	if relation == "comments" {
		return &map[string]jsonapi.Link{
			"related": {
				Href: fmt.Sprintf("https://example.com/posts/%d/comments", post.ID),
				// Optionally include a meta payload
				Meta: map[string]interface{}{
					"count": len(post.Comments),
				},
			},
		}
	}
	return nil
}
```

To include document links,  implement the `Linkable` interface on a struct:

```go
func (post Post) JSONLinks() *map[string]jsonapi.Link {
	return &map[string]jsonapi.Link{
		"self": {
			Href: fmt.Sprintf("https://example.com/posts/%d", post.ID),
		},
	}
}
```