### PR TITLE
Update documentation for responding with proper JSON API headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ func CreateBlog(w http.ResponseWriter, r *http.Request) {
 
 	// ...save your blog...
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", jsonapi.MediaType)
+	w.WriteHeader(http.StatusCreated)
 
 	if err := jsonapi.MarshalOnePayload(w, blog); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -288,8 +288,9 @@ func ListBlogs(w http.ResponseWriter, r *http.Request) {
   // but, for now
 	blogs := testBlogsForList()
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", jsonapi.MediaType)
+	w.WriteHeader(http.StatusOK)
+
 	if err := jsonapi.MarshalManyPayload(w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -325,8 +326,9 @@ func CreateBlogs(w http.ResponseWriter, r *http.Request) {
 		// ...save each of your blogs
 	}
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", jsonapi.MediaType)
+	w.WriteHeader(http.StatusCreated)
+
 	if err := jsonapi.MarshalManyPayload(w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/examples/handler.go
+++ b/examples/handler.go
@@ -105,8 +105,9 @@ func (h *ExampleHandler) listBlogs(w http.ResponseWriter, r *http.Request) {
 	// but, for now
 	blogs := fixtureBlogsList()
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", jsonapi.MediaType)
+	w.WriteHeader(http.StatusOK)
+
 	if err := jsonapiRuntime.MarshalManyPayload(w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/request.go
+++ b/request.go
@@ -55,8 +55,8 @@ var (
 //
 //   	// ...do stuff with your blog...
 //
-//   	w.WriteHeader(201)
 //   	w.Header().Set("Content-Type", jsonapi.MediaType)
+//   	w.WriteHeader(201)
 //
 //   	if err := jsonapi.MarshalOnePayload(w, blog); err != nil {
 //   		http.Error(w, err.Error(), 500)

--- a/response.go
+++ b/response.go
@@ -122,8 +122,9 @@ func MarshalManyPayloadWithoutIncluded(w io.Writer, models interface{}) error {
 //
 //		 blogs := testBlogsForList()
 //
-//		 w.WriteHeader(http.StatusOK)
 //		 w.Header().Set("Content-Type", jsonapi.MediaType)
+//		 w.WriteHeader(http.StatusOK)
+//
 //		 if err := jsonapi.MarshalManyPayload(w, blogs); err != nil {
 //			 http.Error(w, err.Error(), http.StatusInternalServerError)
 //		 }


### PR DESCRIPTION
The current response examples in the README are returning content-type in headers: `text/plain; charset=UTF-8`.

In order to return a proper JSON API content-type `application/vnd.api+json`, the following lines should be reversed:

```
	w.WriteHeader(http.StatusCreated)
	w.Header().Set("Content-Type", jsonapi.MediaType)
```

to:
```
	w.Header().Set("Content-Type", jsonapi.MediaType)
	w.WriteHeader(http.StatusCreated)
```
