### PR TITLE
Add `context.Context` parameter to the model interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /pkg/
 /src/
 /.idea
+.vscode
+*.test

--- a/examples/app.go
+++ b/examples/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -77,7 +78,7 @@ func exerciseHandler() {
 	// create
 	blog := fixtureBlogCreate(1)
 	in := bytes.NewBuffer(nil)
-	jsonapi.MarshalOnePayloadEmbedded(in, blog)
+	jsonapi.MarshalOnePayloadEmbedded(context.Background(), in, blog)
 
 	req, _ = http.NewRequest(http.MethodPost, "/blogs", in)
 
@@ -103,7 +104,7 @@ func exerciseHandler() {
 		fixtureBlogCreate(3),
 	}
 	in = bytes.NewBuffer(nil)
-	jsonapi.MarshalPayload(in, blogs)
+	jsonapi.MarshalPayload(context.Background(), in, blogs)
 
 	req, _ = http.NewRequest(http.MethodPut, "/blogs", in)
 

--- a/examples/handler.go
+++ b/examples/handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -10,6 +11,12 @@ import (
 const (
 	headerAccept      = "Accept"
 	headerContentType = "Content-Type"
+)
+
+type contextKey int
+
+const (
+	keyRequestURI contextKey = iota
 )
 
 // ExampleHandler is the handler we are using to demonstrate building an HTTP
@@ -55,8 +62,8 @@ func (h *ExampleHandler) createBlog(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusCreated)
 	w.Header().Set(headerContentType, jsonapi.MediaType)
-
-	if err := jsonapiRuntime.MarshalPayload(w, blog); err != nil {
+	ctx := context.WithValue(r.Context(), keyRequestURI, r.RequestURI)
+	if err := jsonapiRuntime.MarshalPayload(ctx, w, blog); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -70,7 +77,8 @@ func (h *ExampleHandler) echoBlogs(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set(headerContentType, jsonapi.MediaType)
-	if err := jsonapiRuntime.MarshalPayload(w, blogs); err != nil {
+	ctx := context.WithValue(r.Context(), keyRequestURI, r.RequestURI)
+	if err := jsonapiRuntime.MarshalPayload(ctx, w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -93,7 +101,8 @@ func (h *ExampleHandler) showBlog(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	w.Header().Set(headerContentType, jsonapi.MediaType)
-	if err := jsonapiRuntime.MarshalPayload(w, blog); err != nil {
+	ctx := context.WithValue(r.Context(), keyRequestURI, r.RequestURI)
+	if err := jsonapiRuntime.MarshalPayload(ctx, w, blog); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
@@ -107,8 +116,8 @@ func (h *ExampleHandler) listBlogs(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", jsonapi.MediaType)
 	w.WriteHeader(http.StatusOK)
-
-	if err := jsonapiRuntime.MarshalPayload(w, blogs); err != nil {
+	ctx := context.WithValue(r.Context(), keyRequestURI, r.RequestURI)
+	if err := jsonapiRuntime.MarshalPayload(ctx, w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/examples/handler_test.go
+++ b/examples/handler_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,9 +13,9 @@ import (
 func TestExampleHandler_post(t *testing.T) {
 	blog := fixtureBlogCreate(1)
 	requestBody := bytes.NewBuffer(nil)
-	jsonapi.MarshalOnePayloadEmbedded(requestBody, blog)
+	jsonapi.MarshalOnePayloadEmbedded(context.Background(), requestBody, blog)
 
-	r, err := http.NewRequest(http.MethodPost, "/blogs?id=1", requestBody)
+	r, err := http.NewRequest(http.MethodPost, "https://example.com/blogs?id=1", requestBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,9 +37,9 @@ func TestExampleHandler_put(t *testing.T) {
 		fixtureBlogCreate(3),
 	}
 	requestBody := bytes.NewBuffer(nil)
-	jsonapi.MarshalPayload(requestBody, blogs)
+	jsonapi.MarshalPayload(context.Background(), requestBody, blogs)
 
-	r, err := http.NewRequest(http.MethodPut, "/blogs", requestBody)
+	r, err := http.NewRequest(http.MethodPut, "https://example.com/blogs", requestBody)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +55,7 @@ func TestExampleHandler_put(t *testing.T) {
 }
 
 func TestExampleHandler_get_show(t *testing.T) {
-	r, err := http.NewRequest(http.MethodGet, "/blogs?id=1", nil)
+	r, err := http.NewRequest(http.MethodGet, "https://example.com/blogs?id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +71,7 @@ func TestExampleHandler_get_show(t *testing.T) {
 }
 
 func TestExampleHandler_get_list(t *testing.T) {
-	r, err := http.NewRequest(http.MethodGet, "/blogs", nil)
+	r, err := http.NewRequest(http.MethodGet, "https://example.com/blogs", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/models_test.go
+++ b/models_test.go
@@ -1,9 +1,23 @@
 package jsonapi
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
+
+type key int
+
+const (
+	keyBaseURL key = iota
+	// ...
+)
+
+var testCtx context.Context
+
+func init() {
+	testCtx = context.WithValue(context.Background(), keyBaseURL, "http://example.com")
+}
 
 type BadModel struct {
 	ID int `jsonapi:"primary"`
@@ -78,7 +92,7 @@ type Blog struct {
 	ViewCount     int       `jsonapi:"attr,view_count"`
 }
 
-func (b *Blog) JSONAPILinks() *Links {
+func (b *Blog) JSONAPILinks(ctx context.Context) *Links {
 	return &Links{
 		"self": fmt.Sprintf("https://example.com/api/blogs/%d", b.ID),
 		"comments": Link{
@@ -93,7 +107,7 @@ func (b *Blog) JSONAPILinks() *Links {
 	}
 }
 
-func (b *Blog) JSONAPIRelationshipLinks(relation string) *Links {
+func (b *Blog) JSONAPIRelationshipLinks(ctx context.Context, relation string) *Links {
 	if relation == "posts" {
 		return &Links{
 			"related": Link{
@@ -115,13 +129,13 @@ func (b *Blog) JSONAPIRelationshipLinks(relation string) *Links {
 	return nil
 }
 
-func (b *Blog) JSONAPIMeta() *Meta {
+func (b *Blog) JSONAPIMeta(ctx context.Context) *Meta {
 	return &Meta{
 		"detail": "extra details regarding the blog",
 	}
 }
 
-func (b *Blog) JSONAPIRelationshipMeta(relation string) *Meta {
+func (b *Blog) JSONAPIRelationshipMeta(ctx context.Context, relation string) *Meta {
 	if relation == "posts" {
 		return &Meta{
 			"this": map[string]interface{}{
@@ -150,7 +164,7 @@ type BadComment struct {
 	Body string `jsonapi:"attr,body"`
 }
 
-func (bc *BadComment) JSONAPILinks() *Links {
+func (bc *BadComment) JSONAPILinks(ctx context.Context) *Links {
 	return &Links{
 		"self": []string{"invalid", "should error"},
 	}

--- a/node.go
+++ b/node.go
@@ -1,6 +1,9 @@
 package jsonapi
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Payloader is used to encapsulate the One and Many payload types
 type Payloader interface {
@@ -94,14 +97,14 @@ type Link struct {
 // Linkable is used to include document links in response data
 // e.g. {"self": "http://example.com/posts/1"}
 type Linkable interface {
-	JSONAPILinks() *Links
+	JSONAPILinks(ctx context.Context) *Links
 }
 
 // RelationshipLinkable is used to include relationship links  in response data
 // e.g. {"related": "http://example.com/posts/1/comments"}
 type RelationshipLinkable interface {
 	// JSONAPIRelationshipLinks will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONAPIRelationshipLinks(relation string) *Links
+	JSONAPIRelationshipLinks(ctx context.Context, relation string) *Links
 }
 
 // Meta is used to represent a `meta` object.
@@ -111,11 +114,11 @@ type Meta map[string]interface{}
 // Metable is used to include document meta in response data
 // e.g. {"foo": "bar"}
 type Metable interface {
-	JSONAPIMeta() *Meta
+	JSONAPIMeta(ctx context.Context) *Meta
 }
 
 // RelationshipMetable is used to include relationship meta in response data
 type RelationshipMetable interface {
 	// JSONRelationshipMeta will be invoked for each relationship with the corresponding relation name (e.g. `comments`)
-	JSONAPIRelationshipMeta(relation string) *Meta
+	JSONAPIRelationshipMeta(ctx context.Context, relation string) *Meta
 }

--- a/request_test.go
+++ b/request_test.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -479,7 +480,7 @@ func TestUnmarshalRelationshipsSerializedEmbedded(t *testing.T) {
 
 func TestUnmarshalNestedRelationshipsEmbedded(t *testing.T) {
 	out := bytes.NewBuffer(nil)
-	if err := MarshalOnePayloadEmbedded(out, testModel()); err != nil {
+	if err := MarshalOnePayloadEmbedded(context.Background(), out, testModel()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -931,14 +932,14 @@ func samplePayloadWithSideloaded() io.Reader {
 	testModel := testModel()
 
 	out := bytes.NewBuffer(nil)
-	MarshalPayload(out, testModel)
+	MarshalPayload(testCtx, out, testModel)
 
 	return out
 }
 
 func sampleSerializedEmbeddedTestModel() *Blog {
 	out := bytes.NewBuffer(nil)
-	MarshalOnePayloadEmbedded(out, testModel())
+	MarshalOnePayloadEmbedded(context.Background(), out, testModel())
 
 	blog := new(Blog)
 	UnmarshalPayload(out, blog)

--- a/response_test.go
+++ b/response_test.go
@@ -16,7 +16,7 @@ func TestMarshalPayload(t *testing.T) {
 
 	// One
 	out1 := bytes.NewBuffer(nil)
-	MarshalPayload(out1, book)
+	MarshalPayload(testCtx, out1, book)
 
 	if err := json.Unmarshal(out1.Bytes(), &jsonData); err != nil {
 		t.Fatal(err)
@@ -27,7 +27,7 @@ func TestMarshalPayload(t *testing.T) {
 
 	// Many
 	out2 := bytes.NewBuffer(nil)
-	MarshalPayload(out2, books)
+	MarshalPayload(testCtx, out2, books)
 
 	if err := json.Unmarshal(out2.Bytes(), &jsonData); err != nil {
 		t.Fatal(err)
@@ -42,7 +42,7 @@ func TestMarshal_attrStringSlice(t *testing.T) {
 	b := &Book{ID: 1, Tags: tags}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, b); err != nil {
+	if err := MarshalPayload(testCtx, out, b); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestWithoutOmitsEmptyAnnotationOnRelation(t *testing.T) {
 	blog := &Blog{}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, blog); err != nil {
+	if err := MarshalPayload(testCtx, out, blog); err != nil {
 		t.Fatal(err)
 	}
 
@@ -137,7 +137,7 @@ func TestWithOmitsEmptyAnnotationOnRelation(t *testing.T) {
 	blog := &BlogOptionalPosts{ID: 999}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, blog); err != nil {
+	if err := MarshalPayload(testCtx, out, blog); err != nil {
 		t.Fatal(err)
 	}
 
@@ -169,7 +169,7 @@ func TestWithOmitsEmptyAnnotationOnRelation_MixedData(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, blog); err != nil {
+	if err := MarshalPayload(testCtx, out, blog); err != nil {
 		t.Fatal(err)
 	}
 
@@ -203,7 +203,7 @@ func TestMarshalIDPtr(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, car); err != nil {
+	if err := MarshalPayload(testCtx, out, car); err != nil {
 		t.Fatal(err)
 	}
 
@@ -232,7 +232,7 @@ func TestMarshalOnePayload_omitIDString(t *testing.T) {
 
 	foo := &Foo{Title: "Foo"}
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, foo); err != nil {
+	if err := MarshalPayload(testCtx, out, foo); err != nil {
 		t.Fatal(err)
 	}
 
@@ -258,7 +258,7 @@ func TestMarshall_invalidIDType(t *testing.T) {
 	o := &badIDStruct{ID: &id}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, o); err != ErrBadJSONAPIID {
+	if err := MarshalPayload(testCtx, out, o); err != ErrBadJSONAPIID {
 		t.Fatalf(
 			"Was expecting a `%s` error, got `%s`", ErrBadJSONAPIID, err,
 		)
@@ -272,7 +272,7 @@ func TestOmitsEmptyAnnotation(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, book); err != nil {
+	if err := MarshalPayload(testCtx, out, book); err != nil {
 		t.Fatal(err)
 	}
 
@@ -309,7 +309,7 @@ func TestHasPrimaryAnnotation(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -338,7 +338,7 @@ func TestSupportsAttributes(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -366,7 +366,7 @@ func TestOmitsZeroTimes(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -393,7 +393,7 @@ func TestMarshalISO8601Time(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -421,7 +421,7 @@ func TestMarshalISO8601TimePointer(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -449,7 +449,7 @@ func TestSupportsLinkable(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -518,7 +518,7 @@ func TestInvalidLinkable(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err == nil {
+	if err := MarshalPayload(testCtx, out, testModel); err == nil {
 		t.Fatal("Was expecting an error")
 	}
 }
@@ -531,7 +531,7 @@ func TestSupportsMetable(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -555,7 +555,7 @@ func TestRelations(t *testing.T) {
 	testModel := testBlog()
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -601,7 +601,7 @@ func TestNoRelations(t *testing.T) {
 	testModel := &Blog{ID: 1, Title: "Title 1", CreatedAt: time.Now()}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, testModel); err != nil {
+	if err := MarshalPayload(testCtx, out, testModel); err != nil {
 		t.Fatal(err)
 	}
 
@@ -639,7 +639,7 @@ func TestMarshalPayloadWithoutIncluded(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
+	if err := MarshalPayloadWithoutIncluded(testCtx, out, data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -702,7 +702,7 @@ func TestMarshalPayload_many(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, data); err != nil {
+	if err := MarshalPayload(testCtx, out, data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -725,7 +725,7 @@ func TestMarshalMany_WithSliceOfStructPointers(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayload(out, data); err != nil {
+	if err := MarshalPayload(testCtx, out, data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -748,7 +748,7 @@ func TestMarshalManyWithoutIncluded(t *testing.T) {
 	}
 
 	out := bytes.NewBuffer(nil)
-	if err := MarshalPayloadWithoutIncluded(out, data); err != nil {
+	if err := MarshalPayloadWithoutIncluded(testCtx, out, data); err != nil {
 		t.Fatal(err)
 	}
 
@@ -780,11 +780,11 @@ func TestMarshalMany_SliceOfInterfaceAndSliceOfStructsSameJSON(t *testing.T) {
 
 	// Perform Marshals
 	structsOut := new(bytes.Buffer)
-	if err := MarshalPayload(structsOut, structs); err != nil {
+	if err := MarshalPayload(testCtx, structsOut, structs); err != nil {
 		t.Fatal(err)
 	}
 	interfacesOut := new(bytes.Buffer)
-	if err := MarshalPayload(interfacesOut, interfaces); err != nil {
+	if err := MarshalPayload(testCtx, interfacesOut, interfaces); err != nil {
 		t.Fatal(err)
 	}
 
@@ -806,13 +806,13 @@ func TestMarshalMany_SliceOfInterfaceAndSliceOfStructsSameJSON(t *testing.T) {
 
 func TestMarshal_InvalidIntefaceArgument(t *testing.T) {
 	out := new(bytes.Buffer)
-	if err := MarshalPayload(out, true); err != ErrUnexpectedType {
+	if err := MarshalPayload(testCtx, out, true); err != ErrUnexpectedType {
 		t.Fatal("Was expecting an error")
 	}
-	if err := MarshalPayload(out, 25); err != ErrUnexpectedType {
+	if err := MarshalPayload(testCtx, out, 25); err != ErrUnexpectedType {
 		t.Fatal("Was expecting an error")
 	}
-	if err := MarshalPayload(out, Book{}); err != ErrUnexpectedType {
+	if err := MarshalPayload(testCtx, out, Book{}); err != ErrUnexpectedType {
 		t.Fatal("Was expecting an error")
 	}
 }

--- a/runtime.go
+++ b/runtime.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"io"
@@ -60,9 +61,9 @@ func (r *Runtime) UnmarshalManyPayload(reader io.Reader, kind reflect.Type) (ele
 	return
 }
 
-func (r *Runtime) MarshalPayload(w io.Writer, model interface{}) error {
+func (r *Runtime) MarshalPayload(ctx context.Context, w io.Writer, model interface{}) error {
 	return r.instrumentCall(MarshalStart, MarshalStop, func() error {
-		return MarshalPayload(w, model)
+		return MarshalPayload(ctx, w, model)
 	})
 }
 


### PR DESCRIPTION
Having the `context.Context` parameter in the `JSONAPILinks`,
`JSONAPIMeta`, `JSONAPIRelationshipLinks` and `JSONAPIRelationshipMeta`
allows for accessing contextual information such as the request URI,
which can be used to generate absolute URLs for example.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>