### PR TITLE
Initial implementation of encoding integers to strings

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -9,6 +9,7 @@ const (
 	annotationRelation  = "relation"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
+	annotationString    = "string"
 	annotationSeperator = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"

--- a/models_test.go
+++ b/models_test.go
@@ -31,6 +31,14 @@ type Timestamp struct {
 	Next *time.Time `jsonapi:"attr,next,iso8601"`
 }
 
+type StringInt struct {
+	ID             int    `jsonapi:"primary,string-ints"`
+	ParentID       int    `jsonapi:"attr,parent-id,string"`
+	OptParentID    *int   `jsonapi:"attr,opt-parent-id,string"`
+	BigParentID    int64  `jsonapi:"attr,big-parent-id,string"`
+	OptBigParentID *int64 `jsonapi:"attr,opt-big-parent-id,string"`
+}
+
 type Car struct {
 	ID    *string `jsonapi:"primary,cars"`
 	Make  *string `jsonapi:"attr,make,omitempty"`

--- a/request_test.go
+++ b/request_test.go
@@ -290,6 +290,42 @@ func TestUnmarshalParsesISO8601(t *testing.T) {
 	}
 }
 
+func TestUnmarshalParsesStringInts(t *testing.T) {
+	payload := &OnePayload{
+		Data: &Node{
+			Type: "string-ints",
+			Attributes: map[string]interface{}{
+				"parent-id":         "2",
+				"opt-parent-id":     "3",
+				"big-parent-id":     "1362085645204177151",
+				"opt-big-parent-id": "1362085645204177151",
+			},
+		},
+	}
+
+	in := bytes.NewBuffer(nil)
+	json.NewEncoder(in).Encode(payload)
+
+	out := new(StringInt)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.ParentID != 2 {
+		t.Fatal("Parsing the string encoded int failed")
+	}
+	if *out.OptParentID != 3 {
+		t.Fatal("Parsing the string encoded *int failed")
+	}
+	if out.BigParentID != 1362085645204177151 {
+		t.Fatal("Parsing the string encoded int64 failed")
+	}
+	if *out.OptBigParentID != 1362085645204177151 {
+		t.Fatal("Parsing the string encoded *int64 failed")
+	}
+}
+
 func TestUnmarshalParsesISO8601TimePointer(t *testing.T) {
 	payload := &OnePayload{
 		Data: &Node{

--- a/response.go
+++ b/response.go
@@ -286,7 +286,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				node.ClientID = clientID
 			}
 		} else if annotation == annotationAttribute {
-			var omitEmpty, iso8601 bool
+			var omitEmpty, iso8601, str bool
 
 			if len(args) > 2 {
 				for _, arg := range args[2:] {
@@ -295,6 +295,8 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 						omitEmpty = true
 					case annotationISO8601:
 						iso8601 = true
+					case annotationString:
+						str = true
 					}
 				}
 			}
@@ -345,10 +347,44 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					continue
 				}
 
-				strAttr, ok := fieldValue.Interface().(string)
-				if ok {
-					node.Attributes[args[1]] = strAttr
-				} else {
+				// Modify the output if the user specified that we need to string encode
+				// integer types.
+				switch attr := fieldValue.Interface().(type) {
+				case string:
+					node.Attributes[args[1]] = attr
+				case *int:
+					if attr == nil {
+						node.Attributes[args[1]] = nil
+					} else {
+						if str {
+							node.Attributes[args[1]] = strconv.Itoa(*attr)
+						} else {
+							node.Attributes[args[1]] = fieldValue.Interface()
+						}
+					}
+				case int:
+					if str {
+						node.Attributes[args[1]] = strconv.Itoa(attr)
+					} else {
+						node.Attributes[args[1]] = fieldValue.Interface()
+					}
+				case *int64:
+					if attr == nil {
+						node.Attributes[args[1]] = nil
+					} else {
+						if str {
+							node.Attributes[args[1]] = strconv.FormatInt(*attr, 10)
+						} else {
+							node.Attributes[args[1]] = fieldValue.Interface()
+						}
+					}
+				case int64:
+					if str {
+						node.Attributes[args[1]] = strconv.FormatInt(attr, 10)
+					} else {
+						node.Attributes[args[1]] = fieldValue.Interface()
+					}
+				default:
 					node.Attributes[args[1]] = fieldValue.Interface()
 				}
 			}

--- a/response_test.go
+++ b/response_test.go
@@ -413,6 +413,47 @@ func TestMarshalISO8601Time(t *testing.T) {
 	}
 }
 
+func TestMarshalIntString(t *testing.T) {
+	optParentID := 2
+	optBigParentID := int64(1362085645204177151)
+	testModel := &StringInt{
+		ID:             5,
+		ParentID:       1,
+		OptParentID:    &optParentID,
+		BigParentID:    1362085645204177151,
+		OptBigParentID: &optBigParentID,
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, testModel); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.Attributes == nil {
+		t.Fatalf("Expected attributes")
+	}
+
+	if data.Attributes["parent-id"] != "1" {
+		t.Fatal("ParentID was not serialised as a string correctly")
+	}
+	if data.Attributes["opt-parent-id"] != "2" {
+		t.Fatal("OptParentID was not serialised as a string correctly")
+	}
+	if data.Attributes["big-parent-id"] != "1362085645204177151" {
+		t.Fatal("BigParentID was not serialised as a string correctly")
+	}
+	if data.Attributes["opt-big-parent-id"] != "1362085645204177151" {
+		t.Fatal("OptBigParentID was not serialised as a string correctly")
+	}
+}
+
 func TestMarshalISO8601TimePointer(t *testing.T) {
 	tm := time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC)
 	testModel := &Timestamp{


### PR DESCRIPTION
This is in reference to #120.

I added some code to enable marshalling and unmarshalling the following types to/from `string`s:

- `int`
- `int64`
- `*int`
- `*int64`

To accomplish this, you would use a struct tag of `string`, like the built-in json encoding package. For example:

```go
type Example struct {
  // ...
  ParentID int64 `jsonapi:"attr,parent-id,string"`
  // ...
}
```

I have added tests to verify my new functionality is working as expected and all existing tests still pass, so I don't think I messed with the default behavior by doing this.

Thanks!