### PR TITLE
When unmarshaling, check the payload's type even if no ID is included

### DIFF
--- a/request.go
+++ b/request.go
@@ -154,10 +154,6 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 		}
 
 		if annotation == annotationPrimary {
-			if data.ID == "" {
-				continue
-			}
-
 			// Check the JSON API Type
 			if data.Type != args[1] {
 				er = fmt.Errorf(
@@ -166,6 +162,10 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 					args[1],
 				)
 				break
+			}
+
+			if data.ID == "" {
+				continue
 			}
 
 			// ID will have to be transmitted as astring per the JSON API spec


### PR DESCRIPTION
As of now, `request.unmarshalNode` only checks the payload's `type` field if the `id` field is set. This doesn't make sense when unmarshalling a `POST` payload, as per jsonapi spec the client is not required to set an `id`, but is required to set the correct `type` for the resource they're creating.

This PR addresses this issue by simply moving the type check before the check for an empty `id` field.