### PR TITLE
Fix example execution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ To run,
 * Set `GOPATH` to `PWD` in your shell session, `export GOPATH=$PWD`
 * `go get github.com/google/jsonapi`.  (Append `-u` after `get` if you
   are updating.)
-* `go run $GOPATH/src/github.com/google/jsonapi/examples/app.go` or `cd
-  $GOPATH/src/github.com/google/jsonapi/examples && go run app.go`
+* `cd	$GOPATH/src/github.com/google/jsonapi/examples && go run app.go
+	fixtures.go handler.go models.go` or `cd
+	$GOPATH/src/github.com/google/jsonapi/examples && go build . &&
+	./examples`
 
 ## `jsonapi` Tag Reference
 


### PR DESCRIPTION
If you try to run the example app using the suggested instruction:
`go run $GOPATH/src/github.com/google/jsonapi/examples/app.go`

you get the following errors:

```
# command-line-arguments
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:37:21: undefined: ExampleHandler
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:46:17: undefined: headerAccept
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:63:17: undefined: headerAccept
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:78:10: undefined: fixtureBlogCreate
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:84:17: undefined: headerAccept
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:101:3: undefined: fixtureBlogCreate
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:102:3: undefined: fixtureBlogCreate
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:103:3: undefined: fixtureBlogCreate
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:110:17: undefined: headerAccept
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:125:22: undefined: Blog
/home/doncicuto/go/src/github.com/google/jsonapi/examples/app.go:125:22: too many errors
```
In this PR I suggest changing the last instruction, adding the files required by go run or building the app.