### PR TITLE
Add the Source field in the ErrorObject structure

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -56,8 +56,22 @@ type ErrorObject struct {
 	// Links is an implementation of the JSON API error links payload.
 	Links *ErrorObjectLinks `json:"links,omitempty"`
 
+	// Source is used to indicate which part of the request document caused the error.
+	Source *ErrorSource  `json:"source,omitempty"`
+
 	// Meta is an object containing non-standard meta-information about the error.
 	Meta *map[string]interface{} `json:"meta,omitempty"`
+}
+
+// ErrorSource is a structure containing references to the source of the error, optionally including any of the following members:
+//
+// For more information on the JSON API spec's error objects, see: http://jsonapi.org/format/#error-objects
+type ErrorSource struct {
+	// Pointer is a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].
+	Pointer string `json:"pointer,omitempty"`
+
+	// Parameter is a string indicating which URI query parameter caused the error.
+	Parameter string `json:"parameter,omitempty"`
 }
 
 // Error implements the `Error` interface.

--- a/errors_test.go
+++ b/errors_test.go
@@ -40,6 +40,13 @@ func TestMarshalErrorsWritesTheExpectedPayload(t *testing.T) {
 				map[string]interface{}{"title": "Test title.", "detail": "Test detail", "meta": map[string]interface{}{"key": "val"}},
 			}},
 		},
+		{
+			Title: "TestSourceFieldIsSerializedAsNeeded",
+			In:    []*ErrorObject{{Title: "Test title.", Detail: "Test detail", Source: &ErrorSource{Pointer: "/data/attributes/foobar", Parameter: "foobar"}}},
+			Out: map[string]interface{}{"errors": []interface{}{
+				map[string]interface{}{"title": "Test title.", "detail": "Test detail", "source": map[string]interface{}{"pointer": "/data/attributes/foobar", "parameter": "foobar"}},
+			}},
+		},
 	}
 	for _, testRow := range marshalErrorsTableTasts {
 		t.Run(testRow.Title, func(t *testing.T) {


### PR DESCRIPTION
Closes #130

@denouche FYI, I'm going to bring your PR to my own fork of google/jsonapi to add support for the `Source` field for `ErrorObjects`. I'm impatient, would love to see this get into the main repo though!!