### PR TITLE
Added support for ISO8601 timestamps with time zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,19 @@ types are shown in the examples, but not required.
 #### `attr`
 
 ```
-`jsonapi:"attr,<key name in attributes hash>,<optional: omitempty>"`
+`jsonapi:"attr,<key name in attributes hash>,<optional: omitempty>,<optional: iso8601>"`
 ```
 
 These fields' values will end up in the `attributes`hash for a record.
 The first argument must be, `attr`, and the second should be the name
-for the key to display in the `attributes` hash for that record. The optional
-third argument is `omitempty` - if it is present the field will not be present
+for the key to display in the `attributes` hash for that record. An optional
+argument is `omitempty` - if it is present the field will not be present
 in the `"attributes"` if the field's value is equivalent to the field types
 empty value (ie if the `count` field is of type `int`, `omitempty` will omit the
-field when `count` has a value of `0`). Lastly, the spec indicates that
-`attributes` key names should be dasherized for multiple word field names.
+field when `count` has a value of `0`). An optional argument is `iso8601` - if
+it is present for a time.Time field it will be processed as an iso8601 string
+rather than as a UNIX integer. Lastly, the spec indicates that `attributes` key
+names should be dasherized for multiple word field names.
 
 #### `relation`
 

--- a/constants.go
+++ b/constants.go
@@ -11,9 +11,6 @@ const (
 	annotationISO8601   = "iso8601"
 	annotationSeperator = ","
 
-	iso8601TimeFormat         = "2006-01-02T15:04:05Z"
-	iso8601ExpandedTimeFormat = "2006-01-02T15:04:05-07:00"
-
 	// MediaType is the identifier for the JSON API media type
 	//
 	// see http://jsonapi.org/format/#document-structure

--- a/constants.go
+++ b/constants.go
@@ -11,7 +11,8 @@ const (
 	annotationISO8601   = "iso8601"
 	annotationSeperator = ","
 
-	iso8601TimeFormat = "2006-01-02T15:04:05Z"
+	iso8601TimeFormat         = "2006-01-02T15:04:05Z"
+	iso8601ExpandedTimeFormat = "2006-01-02T15:04:05-07:00"
 
 	// MediaType is the identifier for the JSON API media type
 	//

--- a/request.go
+++ b/request.go
@@ -278,7 +278,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 						break
 					}
 
-					t, err := time.Parse(iso8601TimeFormat, tm)
+					t, err := parseISO8601(tm)
 					if err != nil {
 						er = ErrInvalidISO8601
 						break
@@ -327,7 +327,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 						break
 					}
 
-					v, err := time.Parse(iso8601TimeFormat, tm)
+					v, err := parseISO8601(tm)
 					if err != nil {
 						er = ErrInvalidISO8601
 						break
@@ -547,4 +547,13 @@ func assign(field, value reflect.Value) {
 	} else {
 		field.Set(reflect.Indirect(value))
 	}
+}
+
+// parse8601 attempts to parse time using all supported iso8601 timestamp styles
+func parseISO8601(tm string) (time.Time, error) {
+	v, err := time.Parse(iso8601TimeFormat, tm)
+	if err == nil {
+		return v, err
+	}
+	return time.Parse(iso8601ExpandedTimeFormat, tm)
 }

--- a/request.go
+++ b/request.go
@@ -278,7 +278,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 						break
 					}
 
-					t, err := parseISO8601(tm)
+					t, err := time.Parse(time.RFC3339, tm)
 					if err != nil {
 						er = ErrInvalidISO8601
 						break
@@ -327,7 +327,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 						break
 					}
 
-					v, err := parseISO8601(tm)
+					v, err := time.Parse(time.RFC3339, tm)
 					if err != nil {
 						er = ErrInvalidISO8601
 						break
@@ -547,13 +547,4 @@ func assign(field, value reflect.Value) {
 	} else {
 		field.Set(reflect.Indirect(value))
 	}
-}
-
-// parse8601 attempts to parse time using all supported iso8601 timestamp styles
-func parseISO8601(tm string) (time.Time, error) {
-	v, err := time.Parse(iso8601TimeFormat, tm)
-	if err == nil {
-		return v, err
-	}
-	return time.Parse(iso8601ExpandedTimeFormat, tm)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -290,6 +290,33 @@ func TestUnmarshalParsesISO8601(t *testing.T) {
 	}
 }
 
+func TestUnmarshalParsesExpandedISO8601(t *testing.T) {
+	payload := &OnePayload{
+		Data: &Node{
+			Type: "timestamps",
+			Attributes: map[string]interface{}{
+				"timestamp": "2016-08-17T08:27:12+10:00",
+			},
+		},
+	}
+
+	in := bytes.NewBuffer(nil)
+	json.NewEncoder(in).Encode(payload)
+
+	out := new(Timestamp)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	zone := time.FixedZone("UTC+10", int((10 * time.Hour).Seconds()))
+	expected := time.Date(2016, 8, 17, 8, 27, 12, 0, zone)
+
+	if !out.Time.Equal(expected) {
+		t.Fatal("Parsing the expanded ISO8601 timestamp failed")
+	}
+}
+
 func TestUnmarshalParsesISO8601TimePointer(t *testing.T) {
 	payload := &OnePayload{
 		Data: &Node{

--- a/response.go
+++ b/response.go
@@ -315,7 +315,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				}
 
 				if iso8601 {
-					node.Attributes[args[1]] = t.UTC().Format(time.RFC3339)
+					node.Attributes[args[1]] = t.Format(time.RFC3339)
 				} else {
 					node.Attributes[args[1]] = t.Unix()
 				}
@@ -335,7 +335,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 
 					if iso8601 {
-						node.Attributes[args[1]] = tm.UTC().Format(time.RFC3339)
+						node.Attributes[args[1]] = tm.Format(time.RFC3339)
 					} else {
 						node.Attributes[args[1]] = tm.Unix()
 					}

--- a/response.go
+++ b/response.go
@@ -315,7 +315,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 				}
 
 				if iso8601 {
-					node.Attributes[args[1]] = t.UTC().Format(iso8601TimeFormat)
+					node.Attributes[args[1]] = t.UTC().Format(time.RFC3339)
 				} else {
 					node.Attributes[args[1]] = t.Unix()
 				}
@@ -335,7 +335,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 					}
 
 					if iso8601 {
-						node.Attributes[args[1]] = tm.UTC().Format(iso8601TimeFormat)
+						node.Attributes[args[1]] = tm.UTC().Format(time.RFC3339)
 					} else {
 						node.Attributes[args[1]] = tm.Unix()
 					}


### PR DESCRIPTION
Ref #145 

http://jsonapi.org/recommendations/#date-and-time-fields
https://www.w3.org/TR/NOTE-datetime