### PR TITLE
Implement source in error object

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,6 +23,16 @@ type ErrorsPayload struct {
 	Errors []*ErrorObject `json:"errors"`
 }
 
+// ErrorObject implements the JSON API `source` object (http://jsonapi.org/format/#error-objects).
+type ErrorSource struct {
+	// If the error comes from validating data from a client,
+	// this is the `path` of the attribute that has generated the error.
+	// es. `/data/attributes/email`.
+	Pointer string `json:"pointer,omitempty"`
+	// A string indicating which URI query parameter caused the error.
+	Parameter string `json:"parameter,omitempty"`
+}
+
 // ErrorObject is an `Error` implementation as well as an implementation of the JSON API error object.
 //
 // The main idea behind this struct is that you can use it directly in your code as an error type
@@ -47,6 +57,9 @@ type ErrorObject struct {
 
 	// Meta is an object containing non-standard meta-information about the error.
 	Meta *map[string]interface{} `json:"meta,omitempty"`
+
+	// Source contains reference to the source of the error.
+	Source *ErrorSource `json:"source,omitempty"`
 }
 
 // Error implements the `Error` interface.

--- a/errors_test.go
+++ b/errors_test.go
@@ -40,6 +40,13 @@ func TestMarshalErrorsWritesTheExpectedPayload(t *testing.T) {
 				map[string]interface{}{"title": "Test title.", "detail": "Test detail", "meta": map[string]interface{}{"key": "val"}},
 			}},
 		},
+		{
+			Title: "TestSourceFieldIsSerializedProperly",
+			In:    []*ErrorObject{{Source: &ErrorSource{Pointer: "/data/attributes/email", Parameter: "email"}}},
+			Out: map[string]interface{}{"errors": []interface{}{
+				map[string]interface{}{"source": map[string]interface{}{"pointer": "/data/attributes/email", "parameter": "email"}},
+			}},
+		},
 	}
 	for _, testRow := range marshalErrorsTableTasts {
 		t.Run(testRow.Title, func(t *testing.T) {


### PR DESCRIPTION
Some applications (es. [Emberjs](https://emberjs.com/)) use `source` object in json api error to show messages returned from backend to users.
This PR extends `ErrorObject` to optionally  include `source` object.
ref:
https://stackoverflow.com/questions/31918565/handling-errors-with-the-now-default-ember-data-json-api-adapter
http://jsonapi.org/format/#error-objects 