### PR TITLE
adds (un)marshaling of struct attributes

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -67,12 +67,21 @@ type Book struct {
 	Tags        []string `jsonapi:"attr,tags"`
 }
 
+type Author struct {
+	Firstname    string                 `jsonapi:"firstname"`
+	Lastname     string                 `jsonapi:"lastname"`
+	Age          int                    `jsonapi:"age"`
+	Publications []int                  `jsonapi:"publications"`
+	Skills       map[string]interface{} `jsonapi:"skills"`
+}
+
 type Blog struct {
 	ID            int       `jsonapi:"primary,blogs"`
 	ClientID      string    `jsonapi:"client-id"`
 	Title         string    `jsonapi:"attr,title"`
 	Posts         []*Post   `jsonapi:"relation,posts"`
 	CurrentPost   *Post     `jsonapi:"relation,current_post"`
+	Author        *Author   `jsonapi:"attr,author"`
 	CurrentPostID int       `jsonapi:"attr,current_post_id"`
 	CreatedAt     time.Time `jsonapi:"attr,created_at"`
 	ViewCount     int       `jsonapi:"attr,view_count"`

--- a/request_test.go
+++ b/request_test.go
@@ -564,6 +564,31 @@ func TestUnmarshalNestedRelationshipsEmbedded_withClientIDs(t *testing.T) {
 	}
 }
 
+func TestUnmarshalNestedStruct(t *testing.T) {
+	payload := samplePayloadWithSideloaded()
+	out := new(Blog)
+
+	if err := UnmarshalPayload(payload, out); err != nil {
+		t.Fatal(err)
+	}
+
+	if out.Author.Age != 10 {
+		t.Errorf("Author Age not set from request")
+	}
+	if out.Author.Firstname != "Mr" {
+		t.Errorf("Author Firstname not set from request")
+	}
+	if out.Author.Lastname != "Gopher" {
+		t.Errorf("Author Lastname not set from request")
+	}
+	if len(out.Author.Publications) != 3 || out.Author.Publications[0] != 1998 {
+		t.Errorf("Author Publications not set from request")
+	}
+	if len(out.Author.Skills) != 1 || out.Author.Skills["english"] != "native" {
+		t.Errorf("Author Skills not set from request")
+	}
+}
+
 func unmarshalSamplePayload() (*Blog, error) {
 	in := samplePayload()
 	out := new(Blog)
@@ -865,6 +890,15 @@ func testModel() *Blog {
 		ClientID:  "1",
 		Title:     "Title 1",
 		CreatedAt: time.Now(),
+		Author: &Author{
+			Firstname:    "Mr",
+			Lastname:     "Gopher",
+			Age:          10,
+			Publications: []int{1998, 2000, 2002},
+			Skills: map[string]interface{}{
+				"english": "native",
+			},
+		},
 		Posts: []*Post{
 			{
 				ID:    1,


### PR DESCRIPTION
This commit adds the option to marshal and unmarshal structs as attributes.
These structs don't reperent regzukat resource objects and shouldn't have type and id fields.
The repsective "Attributes" section from the json spec:

> Complex data structures involving JSON objects and arrays are allowed as attribute values. However, any object that constitutes or is contained in an attribute MUST NOT contain a relationships or links member, as those members are reserved by this specification for future use.