### PR TITLE
Add support for attributes of custom defined types

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -176,3 +176,18 @@ type Employee struct {
 	Age       int        `jsonapi:"attr,age"`
 	HiredAt   *time.Time `jsonapi:"attr,hired-at,iso8601"`
 }
+
+type CustomIntType int
+type CustomFloatType float64
+type CustomStringType string
+
+type CustomAttributeTypes struct {
+	ID string `jsonapi:"primary,customtypes"`
+
+	Int        CustomIntType  `jsonapi:"attr,int"`
+	IntPtr     *CustomIntType `jsonapi:"attr,intptr"`
+	IntPtrNull *CustomIntType `jsonapi:"attr,intptrnull"`
+
+	Float  CustomFloatType  `jsonapi:"attr,float"`
+	String CustomStringType `jsonapi:"attr,string"`
+}

--- a/request.go
+++ b/request.go
@@ -254,10 +254,10 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 			}
 
 			// As a final catch-all, ensure types line up to avoid a runtime panic.
-			if fieldValue.Kind() != v.Kind() {
+			if fieldValue.Kind() != value.Kind() {
 				return ErrInvalidType
 			}
-			assignValue(fieldValue, reflect.ValueOf(val))
+			assignValue(fieldValue, value)
 		} else if annotation == annotationRelation {
 			isSlice := fieldValue.Type().Kind() == reflect.Slice
 

--- a/request_test.go
+++ b/request_test.go
@@ -799,17 +799,17 @@ func TestUnmarshalCustomTypeAttributes(t *testing.T) {
 	}
 
 	if expected, actual := customInt, customAttributeTypes.Int; expected != actual {
-		t.Fatalf("Was expecting custom int to be `%s`, got `%s`", expected, actual)
+		t.Fatalf("Was expecting custom int to be `%d`, got `%d`", expected, actual)
 	}
 	if expected, actual := customInt, *customAttributeTypes.IntPtr; expected != actual {
-		t.Fatalf("Was expecting custom int pointer to be `%s`, got `%s`", expected, actual)
+		t.Fatalf("Was expecting custom int pointer to be `%d`, got `%d`", expected, actual)
 	}
 	if customAttributeTypes.IntPtrNull != nil {
-		t.Fatalf("Was expecting custom int pointer to be <nil>, got `%s`", customAttributeTypes.IntPtrNull)
+		t.Fatalf("Was expecting custom int pointer to be <nil>, got `%d`", customAttributeTypes.IntPtrNull)
 	}
 
 	if expected, actual := customFloat, customAttributeTypes.Float; expected != actual {
-		t.Fatalf("Was expecting custom float to be `%s`, got `%s`", expected, actual)
+		t.Fatalf("Was expecting custom float to be `%f`, got `%f`", expected, actual)
 	}
 	if expected, actual := customString, customAttributeTypes.String; expected != actual {
 		t.Fatalf("Was expecting custom string to be `%s`, got `%s`", expected, actual)

--- a/request_test.go
+++ b/request_test.go
@@ -768,6 +768,54 @@ func TestManyPayload_withLinks(t *testing.T) {
 	}
 }
 
+func TestUnmarshalCustomTypeAttributes(t *testing.T) {
+	customInt := CustomIntType(5)
+	customFloat := CustomFloatType(1.5)
+	customString := CustomStringType("Test")
+
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "customtypes",
+			"id":   "1",
+			"attributes": map[string]interface{}{
+				"int":        customInt,
+				"intptr":     &customInt,
+				"intptrnull": nil,
+
+				"float":  customFloat,
+				"string": customString,
+			},
+		},
+	}
+	payload, err := payload(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Parse JSON API payload
+	customAttributeTypes := new(CustomAttributeTypes)
+	if err := UnmarshalPayload(bytes.NewReader(payload), customAttributeTypes); err != nil {
+		t.Fatal(err)
+	}
+
+	if expected, actual := customInt, customAttributeTypes.Int; expected != actual {
+		t.Fatalf("Was expecting custom int to be `%s`, got `%s`", expected, actual)
+	}
+	if expected, actual := customInt, *customAttributeTypes.IntPtr; expected != actual {
+		t.Fatalf("Was expecting custom int pointer to be `%s`, got `%s`", expected, actual)
+	}
+	if customAttributeTypes.IntPtrNull != nil {
+		t.Fatalf("Was expecting custom int pointer to be <nil>, got `%s`", customAttributeTypes.IntPtrNull)
+	}
+
+	if expected, actual := customFloat, customAttributeTypes.Float; expected != actual {
+		t.Fatalf("Was expecting custom float to be `%s`, got `%s`", expected, actual)
+	}
+	if expected, actual := customString, customAttributeTypes.String; expected != actual {
+		t.Fatalf("Was expecting custom string to be `%s`, got `%s`", expected, actual)
+	}
+}
+
 func samplePayloadWithoutIncluded() map[string]interface{} {
 	return map[string]interface{}{
 		"data": map[string]interface{}{

--- a/request_test.go
+++ b/request_test.go
@@ -778,12 +778,12 @@ func TestUnmarshalCustomTypeAttributes(t *testing.T) {
 			"type": "customtypes",
 			"id":   "1",
 			"attributes": map[string]interface{}{
-				"int":        customInt,
-				"intptr":     &customInt,
+				"int":        5,
+				"intptr":     5,
 				"intptrnull": nil,
 
-				"float":  customFloat,
-				"string": customString,
+				"float":  1.5,
+				"string": "Test",
 			},
 		},
 	}


### PR DESCRIPTION
This is https://github.com/google/jsonapi/pull/136 rebased on top of current google/jsonapi master after merge of https://github.com/google/jsonapi/pull/99.

Small adjustments were made,
1) Updated request.go to address change in structure of handle attribute block
2) Changed inputs to test for custom types so that where primitives instead of complex values.  Tests still pass.