### PR TITLE
Improve handleStruct to use struct's own Unmarshaler if it is available

### DIFF
--- a/request.go
+++ b/request.go
@@ -591,7 +591,19 @@ func handlePointer(
 func handleStruct(
 	attribute interface{},
 	fieldValue reflect.Value) (reflect.Value, error) {
-
+	if fieldValue.CanAddr() {
+		interf := fieldValue.Addr().Interface()
+		if _, ok := interf.(json.Unmarshaler); ok {
+			var tmp []byte
+			tmp, err := json.Marshal(attribute)
+			if err == nil {
+				err = json.Unmarshal(tmp, interf)
+				if err == nil {
+					return reflect.ValueOf(interf), nil
+				}
+			}
+		}
+	}
 	data, err := json.Marshal(attribute)
 	if err != nil {
 		return reflect.Value{}, err


### PR DESCRIPTION
`handleStruct` wasn't properly handling structs with custom marshaler/unmarshaler.

With this PR `handleStruct` correctly handles structs which implement the `json.Unmarshaler` interface.