### PR TITLE
Add support for meta annotations on model fields

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -7,6 +7,7 @@ const (
 	annotationClientID  = "client-id"
 	annotationAttribute = "attr"
 	annotationRelation  = "relation"
+	annotationMeta      = "meta"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
 	annotationSeperator = ","

--- a/models_test.go
+++ b/models_test.go
@@ -68,15 +68,16 @@ type Book struct {
 }
 
 type Blog struct {
-	ID            int       `jsonapi:"primary,blogs"`
-	ClientID      string    `jsonapi:"client-id"`
-	Title         string    `jsonapi:"attr,title"`
-	Posts         []*Post   `jsonapi:"relation,posts"`
-	CurrentPost   *Post     `jsonapi:"relation,current_post"`
-	CurrentPostID int       `jsonapi:"attr,current_post_id"`
-	CreatedAt     time.Time `jsonapi:"attr,created_at"`
-	ModifiedAt    time.Time `jsonapi:"meta,modified_at,iso8601"`
-	ViewCount     int       `jsonapi:"attr,view_count"`
+	ID              int       `jsonapi:"primary,blogs"`
+	ClientID        string    `jsonapi:"client-id"`
+	Title           string    `jsonapi:"attr,title"`
+	Posts           []*Post   `jsonapi:"relation,posts"`
+	CurrentPost     *Post     `jsonapi:"relation,current_post"`
+	CurrentPostID   int       `jsonapi:"attr,current_post_id"`
+	CreatedAt       time.Time `jsonapi:"attr,created_at"`
+	ModifiedAt      time.Time `jsonapi:"meta,modified_at,iso8601"`
+	ViewCount       int       `jsonapi:"attr,view_count"`
+	ResourceVersion string    `jsonapi:"meta,resource_version"`
 }
 
 func (b *Blog) JSONAPILinks() *Links {

--- a/models_test.go
+++ b/models_test.go
@@ -75,7 +75,8 @@ type Blog struct {
 	CurrentPost     *Post     `jsonapi:"relation,current_post"`
 	CurrentPostID   int       `jsonapi:"attr,current_post_id"`
 	CreatedAt       time.Time `jsonapi:"attr,created_at"`
-	ModifiedAt      time.Time `jsonapi:"meta,modified_at,iso8601"`
+	ModifiedAt      time.Time `jsonapi:"meta,modified_at"` // not iso 8601, serialize as epoch time
+	DeletedAt       time.Time `jsonapi:"meta,deleted_at,iso8601"`
 	ViewCount       int       `jsonapi:"attr,view_count"`
 	ResourceVersion string    `jsonapi:"meta,resource_version"`
 }

--- a/models_test.go
+++ b/models_test.go
@@ -75,6 +75,7 @@ type Blog struct {
 	CurrentPost   *Post     `jsonapi:"relation,current_post"`
 	CurrentPostID int       `jsonapi:"attr,current_post_id"`
 	CreatedAt     time.Time `jsonapi:"attr,created_at"`
+	ModifiedAt    time.Time `jsonapi:"meta,modified_at,iso8601"`
 	ViewCount     int       `jsonapi:"attr,view_count"`
 }
 

--- a/request.go
+++ b/request.go
@@ -235,7 +235,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 		} else if annotation == annotationAttribute {
 			attributes := data.Attributes
 
-			if attributes == nil || len(data.Attributes) == 0 {
+			if attributes == nil || len(attributes) == 0 {
 				continue
 			}
 
@@ -324,6 +324,28 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 			}
 
+		} else if annotation == annotationMeta {
+			meta := data.Meta
+
+			if meta == nil || len(*meta) == 0 {
+				continue
+			}
+
+			m := (*meta)[args[1]]
+
+			// continue if the m was not included in the request
+			if m == nil {
+				continue
+			}
+
+			structField := fieldType
+			value, err := unmarshalAttribute(m, args, structField, fieldValue)
+			if err != nil {
+				er = err
+				break
+			}
+
+			assign(fieldValue, value)
 		} else {
 			er = fmt.Errorf(unsupportedStructTagMsg, annotation)
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -854,6 +854,38 @@ func TestUnmarshalCustomTypeAttributes_ErrInvalidType(t *testing.T) {
 	}
 }
 
+func TestUnmarshalPayloadMeta(t *testing.T) {
+	modifiedAt, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := &OnePayload{
+		Data: &Node{
+			Type: "heavymeta",
+			Meta: &Meta{
+				"modified_at": modifiedAt,
+			},
+		},
+	}
+
+	in := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(in).Encode(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	out := new(Blog)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	actual := out.ModifiedAt
+
+	if actual != modifiedAt {
+		t.Fatal("Reading the meta failed")
+	}
+}
+
 func samplePayloadWithoutIncluded() map[string]interface{} {
 	return map[string]interface{}{
 		"data": map[string]interface{}{

--- a/request_test.go
+++ b/request_test.go
@@ -863,7 +863,7 @@ func TestUnmarshalPayloadMeta(t *testing.T) {
 		Data: &Node{
 			Type: "heavymeta",
 			Meta: &Meta{
-				"modified_at": modifiedAt,
+				"modified_at": modifiedAt.Unix(), // timezone is lost here
 			},
 		},
 	}
@@ -879,10 +879,10 @@ func TestUnmarshalPayloadMeta(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual := out.ModifiedAt
+	actual := out.ModifiedAt.In(time.UTC) // have to re-add the timezone here
 
 	if actual != modifiedAt {
-		t.Fatal("Reading the meta failed")
+		t.Fatalf("Reading the meta failed %#v != %#v", actual, modifiedAt)
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -442,6 +442,40 @@ func TestSupportsAttributes(t *testing.T) {
 	}
 }
 
+func TestSupportsMetaAnnotation(t *testing.T) {
+	modifiedAt, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testModel := &Blog{
+		ID:         5,
+		Title:      "Title 1",
+		CreatedAt:  time.Now(),
+		ModifiedAt: modifiedAt,
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, testModel); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.Meta == nil {
+		t.Fatalf("Expected meta")
+	}
+
+	if (*data.Meta)["modified_at"] != "2006-01-02T15:04:05Z" {
+		t.Fatalf("Meta hash not populated using tags correctly %#v", *data.Meta)
+	}
+}
+
 func TestOmitsZeroTimes(t *testing.T) {
 	testModel := &Blog{
 		ID:        5,

--- a/response_test.go
+++ b/response_test.go
@@ -449,10 +449,11 @@ func TestSupportsMetaAnnotation(t *testing.T) {
 	}
 
 	testModel := &Blog{
-		ID:         5,
-		Title:      "Title 1",
-		CreatedAt:  time.Now(),
-		ModifiedAt: modifiedAt,
+		ID:              5,
+		Title:           "Title 1",
+		CreatedAt:       time.Now(),
+		ModifiedAt:      modifiedAt,
+		ResourceVersion: "etag987abc",
 	}
 
 	out := bytes.NewBuffer(nil)
@@ -471,8 +472,12 @@ func TestSupportsMetaAnnotation(t *testing.T) {
 		t.Fatalf("Expected meta")
 	}
 
-	if (*data.Meta)["modified_at"] != "2006-01-02T15:04:05Z" {
-		t.Fatalf("Meta hash not populated using tags correctly %#v", *data.Meta)
+	if (*data.Meta)["resource_version"] != "etag987abc" {
+		t.Fatalf("Meta hash not populating time fields correctly %#v", *data.Meta)
+	}
+
+	if (*data.Meta)["modified_at"] != modifiedAt.Format(time.RFC3339) {
+		t.Fatalf("Meta hash not populating time fields correctly %#v", *data.Meta)
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -453,6 +453,7 @@ func TestSupportsMetaAnnotation(t *testing.T) {
 		Title:           "Title 1",
 		CreatedAt:       time.Now(),
 		ModifiedAt:      modifiedAt,
+		DeletedAt:       modifiedAt,
 		ResourceVersion: "etag987abc",
 	}
 
@@ -476,8 +477,18 @@ func TestSupportsMetaAnnotation(t *testing.T) {
 		t.Fatalf("Meta hash not populating time fields correctly %#v", *data.Meta)
 	}
 
-	if (*data.Meta)["modified_at"] != modifiedAt.Format(time.RFC3339) {
-		t.Fatalf("Meta hash not populating time fields correctly %#v", *data.Meta)
+	// encoding/json automatically makes this a float64 because json just specifies "number"
+	mod, ok := (*data.Meta)["modified_at"].(float64)
+	if !ok {
+		t.Fatal("Epoch time is not accessible as a float64")
+	}
+	actualModified := int64(mod)
+	if actualModified != modifiedAt.Unix() {
+		t.Fatalf("Meta hash not populating epoch time fields correctly %T: %T", modifiedAt.Unix(), actualModified)
+	}
+
+	if (*data.Meta)["deleted_at"] != modifiedAt.Format(time.RFC3339) {
+		t.Fatalf("Meta hash not populating iso8601 time fields correctly %#v %#v", modifiedAt.Format(time.RFC3339), (*data.Meta)["deleted_at"])
 	}
 }
 


### PR DESCRIPTION
Instead of using the `JSONAPIMeta()` hook, allow specifying metadata directly in the model/node.

```
type Blog struct {
	ID              int       `jsonapi:"primary,blogs"`
	Title           string    `jsonapi:"attr,title"`
	ModifiedAt      time.Time `jsonapi:"meta,modified_at"` // not iso 8601, serialize as epoch time
	DeletedAt       time.Time `jsonapi:"meta,deleted_at,iso8601"`
	ResourceVersion string    `jsonapi:"meta,resource_version"`
}
```

This supports epoch timestamps, iso8601 datetime strings, and other stringify-able data types.