### PR TITLE
Add support to unmarshal struct

### DIFF
--- a/request.go
+++ b/request.go
@@ -434,6 +434,22 @@ func unmarshalAttribute(
 	return
 }
 
+func handleIntSlice(
+	attribute interface{},
+	fieldType reflect.Type,
+	fieldValue reflect.Value) (reflect.Value, error) {
+	
+	v := reflect.ValueOf(attribute)
+
+	values := make([]int, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		ve := v.Index(i)
+		values[i] = int(ve.Interface().(float64))
+	}
+
+	return reflect.ValueOf(values), nil
+}
+
 func handleStringSlice(attribute interface{}) (reflect.Value, error) {
 	v := reflect.ValueOf(attribute)
 	values := make([]string, v.Len())


### PR DESCRIPTION
This is a feature to add support for unmarshalling int slices. in the request.go file, we've different functions to handle string slices, time, numeric .. and so on. we needed to add a function to also be able to handle a slice containing a lit of integers