### PR TITLE
[FIX] Issue 176

### DIFF
--- a/request.go
+++ b/request.go
@@ -175,10 +175,6 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 		}
 
 		if annotation == annotationPrimary {
-			if data.ID == "" {
-				continue
-			}
-
 			// Check the JSON API Type
 			if data.Type != args[1] {
 				er = fmt.Errorf(
@@ -187,6 +183,10 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 					args[1],
 				)
 				break
+			}
+
+			if data.ID == "" {
+				continue
 			}
 
 			// ID will have to be transmitted as astring per the JSON API spec

--- a/request_test.go
+++ b/request_test.go
@@ -73,8 +73,8 @@ func TestUnmarshalToStructWithPointerAttr(t *testing.T) {
 func TestUnmarshalPayload_ptrsAllNil(t *testing.T) {
 	out := new(WithPointer)
 	if err := UnmarshalPayload(
-		strings.NewReader(`{"data": {}}`), out); err != nil {
-		t.Fatalf("Error unmarshalling to Foo")
+		strings.NewReader(`{"data": {"type":"with-pointers"}}`), out); err != nil {
+		t.Fatalf("Error unmarshalling to Foo: %s", err.Error())
 	}
 
 	if out.ID != nil {


### PR DESCRIPTION
This pull request fixes issue #176.

Like @noboevbo rightly pointed out, the JSON:API [spec](https://jsonapi.org/format/#crud) dictates that the `type` member is always required.

As of now, if the resource object doesn't contain an id (valid scenario on a request), the type check is skipped.

This minor change updates the logic in order to enforce the type check, regardless if an id value is present or not.

Credits go to @noboevbo for pointing the solution in the original issue.