### PR TITLE
[FIX] Issue #122 / Add database/sql null type support

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -9,7 +9,7 @@ const (
 	annotationRelation  = "relation"
 	annotationOmitEmpty = "omitempty"
 	annotationISO8601   = "iso8601"
-	annotationSeperator = ","
+	annotationSeparator = ","
 
 	iso8601TimeFormat = "2006-01-02T15:04:05Z"
 

--- a/models_test.go
+++ b/models_test.go
@@ -55,6 +55,16 @@ type NullFloat64ID struct {
 	ID sql.NullFloat64 `jsonapi:"primary,null-float64-id"`
 }
 
+type Float struct {
+	ID         sql.NullString  `jsonapi:"primary,float"`
+	Periodic   sql.NullBool    `jsonapi:"attr,periodic"`
+	Name       sql.NullString  `jsonapi:"attr,name"`
+	Value      sql.NullFloat64 `jsonapi:"attr,value"`
+	Decimal    sql.NullInt32   `jsonapi:"attr,decimal"`
+	Fractional sql.NullInt64   `jsonapi:"attr,fractional"`
+	ComputedAt sql.NullTime    `jsonapi:"attr,computed_at"`
+}
+
 type Car struct {
 	ID    *string `jsonapi:"primary,cars"`
 	Make  *string `jsonapi:"attr,make,omitempty"`

--- a/models_test.go
+++ b/models_test.go
@@ -34,14 +34,13 @@ type Timestamp struct {
 }
 
 type NullStringID struct {
-	ID            sql.NullString  `jsonapi:"primary,null-string-id"`
-	Periodic      sql.NullBool    `jsonapi:"attr,periodic,omitempty"`
-	Name          sql.NullString  `jsonapi:"attr,name,omitempty"`
-	Value         sql.NullFloat64 `jsonapi:"attr,value,omitempty"`
-	Decimal       sql.NullInt32   `jsonapi:"attr,decimal,omitempty"`
-	Fractional    sql.NullInt64   `jsonapi:"attr,fractional,omitempty"`
-	ComputedAt    sql.NullTime    `jsonapi:"attr,computed_at,omitempty"`
-	ComputedAtISO sql.NullTime    `jsonapi:"attr,computed_at_iso,iso8601,omitempty"`
+	ID         sql.NullString  `jsonapi:"primary,null-string-id"`
+	Periodic   sql.NullBool    `jsonapi:"attr,periodic,omitempty"`
+	Name       sql.NullString  `jsonapi:"attr,name,omitempty"`
+	Value      sql.NullFloat64 `jsonapi:"attr,value,omitempty"`
+	Decimal    sql.NullInt32   `jsonapi:"attr,decimal,omitempty"`
+	Fractional sql.NullInt64   `jsonapi:"attr,fractional,omitempty"`
+	ComputedAt sql.NullTime    `jsonapi:"attr,computed_at,omitempty,iso8601"`
 }
 
 type NullInt32ID struct {

--- a/models_test.go
+++ b/models_test.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 )
@@ -26,9 +27,33 @@ type WithPointer struct {
 }
 
 type Timestamp struct {
-	ID   int        `jsonapi:"primary,timestamps"`
-	Time time.Time  `jsonapi:"attr,timestamp,iso8601"`
-	Next *time.Time `jsonapi:"attr,next,iso8601"`
+	ID   int          `jsonapi:"primary,timestamps"`
+	Time time.Time    `jsonapi:"attr,timestamp,iso8601"`
+	Next *time.Time   `jsonapi:"attr,next,iso8601"`
+	Null sql.NullTime `jsonapi:"attr,null,iso8601"`
+}
+
+type NullStringID struct {
+	ID            sql.NullString  `jsonapi:"primary,null-string-id"`
+	Periodic      sql.NullBool    `jsonapi:"attr,periodic,omitempty"`
+	Name          sql.NullString  `jsonapi:"attr,name,omitempty"`
+	Value         sql.NullFloat64 `jsonapi:"attr,value,omitempty"`
+	Decimal       sql.NullInt32   `jsonapi:"attr,decimal,omitempty"`
+	Fractional    sql.NullInt64   `jsonapi:"attr,fractional,omitempty"`
+	ComputedAt    sql.NullTime    `jsonapi:"attr,computed_at,omitempty"`
+	ComputedAtISO sql.NullTime    `jsonapi:"attr,computed_at_iso,iso8601,omitempty"`
+}
+
+type NullInt32ID struct {
+	ID sql.NullInt32 `jsonapi:"primary,null-int32-id"`
+}
+
+type NullInt64ID struct {
+	ID sql.NullInt64 `jsonapi:"primary,null-int64-id"`
+}
+
+type NullFloat64ID struct {
+	ID sql.NullFloat64 `jsonapi:"primary,null-float64-id"`
 }
 
 type Car struct {

--- a/request.go
+++ b/request.go
@@ -256,6 +256,15 @@ func unmarshallID(node *Node, fieldValue reflect.Value, structField reflect.Stru
 		return node, nil
 	}
 
+	// Handle sql.NullString case
+	if structField.Type == reflect.TypeOf(sql.NullString{}) {
+		if str, ok := v.Interface().(string); ok {
+			assign(fieldValue, reflect.ValueOf(sql.NullString{String: str, Valid: true}))
+
+			return node, nil
+		}
+	}
+
 	// Value was not a string... only other supported type was a numeric,
 	// which would have been sent as a float value.
 	floatValue, err := strconv.ParseFloat(node.ID, 64)

--- a/request.go
+++ b/request.go
@@ -482,6 +482,10 @@ func handleTime(attribute interface{}, args []string, fieldValue reflect.Value) 
 			return reflect.ValueOf(time.Now()), ErrInvalidISO8601
 		}
 
+		if _, ok := fieldValue.Interface().(sql.NullTime); ok {
+			return reflect.ValueOf(sql.NullTime{Time: t, Valid: true}), nil
+		}
+
 		if fieldValue.Kind() == reflect.Ptr {
 			return reflect.ValueOf(&t), nil
 		}
@@ -497,6 +501,10 @@ func handleTime(attribute interface{}, args []string, fieldValue reflect.Value) 
 		t = time.Unix(v.Int(), 0)
 	} else {
 		return reflect.ValueOf(time.Now()), ErrInvalidTime
+	}
+
+	if _, ok := fieldValue.Interface().(sql.NullTime); ok {
+		return reflect.ValueOf(sql.NullTime{Time: t, Valid: true}), nil
 	}
 
 	return reflect.ValueOf(t), nil

--- a/request.go
+++ b/request.go
@@ -472,14 +472,11 @@ func handleTime(attribute interface{}, args []string, fieldValue reflect.Value) 
 	}
 
 	if isIso8601 {
-		var tm string
-		if v.Kind() == reflect.String {
-			tm = v.Interface().(string)
-		} else {
+		if v.Kind() != reflect.String {
 			return reflect.ValueOf(time.Now()), ErrInvalidISO8601
 		}
 
-		t, err := time.Parse(iso8601TimeFormat, tm)
+		t, err := time.Parse(iso8601TimeFormat, v.Interface().(string))
 		if err != nil {
 			return reflect.ValueOf(time.Now()), ErrInvalidISO8601
 		}

--- a/request.go
+++ b/request.go
@@ -488,17 +488,15 @@ func handleTime(attribute interface{}, args []string, fieldValue reflect.Value) 
 		return reflect.ValueOf(t), nil
 	}
 
-	var at int64
+	var t time.Time
 
 	if v.Kind() == reflect.Float64 {
-		at = int64(v.Interface().(float64))
+		t = time.Unix(int64(v.Float()), 0)
 	} else if v.Kind() == reflect.Int {
-		at = v.Int()
+		t = time.Unix(v.Int(), 0)
 	} else {
 		return reflect.ValueOf(time.Now()), ErrInvalidTime
 	}
-
-	t := time.Unix(at, 0)
 
 	return reflect.ValueOf(t), nil
 }

--- a/request.go
+++ b/request.go
@@ -641,17 +641,8 @@ func handlePointer(
 
 func isSQLNullType(fieldType reflect.Type) bool {
 	switch fieldType {
-	case reflect.TypeOf(sql.NullString{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullBool{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullInt32{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullInt64{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullFloat64{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullTime{}):
+	case reflect.TypeOf(sql.NullString{}), reflect.TypeOf(sql.NullBool{}), reflect.TypeOf(sql.NullInt32{}),
+		reflect.TypeOf(sql.NullInt64{}), reflect.TypeOf(sql.NullFloat64{}), reflect.TypeOf(sql.NullTime{}):
 		return true
 	}
 
@@ -665,11 +656,7 @@ func handleSQLNullType(attribute interface{}, args []string, fieldType reflect.T
 		return reflect.ValueOf(sql.NullString{String: attribute.(string), Valid: true}), nil
 	case reflect.TypeOf(sql.NullBool{}):
 		return reflect.ValueOf(sql.NullBool{Bool: attribute.(bool), Valid: true}), nil
-	case reflect.TypeOf(sql.NullInt32{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullInt64{}):
-		fallthrough
-	case reflect.TypeOf(sql.NullFloat64{}):
+	case reflect.TypeOf(sql.NullInt32{}), reflect.TypeOf(sql.NullInt64{}), reflect.TypeOf(sql.NullFloat64{}):
 		return handleNumeric(attribute, fieldType, fieldValue)
 	case reflect.TypeOf(sql.NullTime{}):
 		return handleTime(attribute, args, fieldValue)

--- a/request.go
+++ b/request.go
@@ -232,7 +232,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 	return nil
 }
 
-func unmarshallID(node *Node, fieldValue reflect.Value, fieldType reflect.StructField) (*Node, error) {
+func unmarshallID(node *Node, fieldValue reflect.Value, structField reflect.StructField) (*Node, error) {
 	if node.ID == "" {
 		return node, nil
 	}
@@ -243,9 +243,9 @@ func unmarshallID(node *Node, fieldValue reflect.Value, fieldType reflect.Struct
 	// Deal with PTRS
 	var kind reflect.Kind
 	if fieldValue.Kind() == reflect.Ptr {
-		kind = fieldType.Type.Elem().Kind()
+		kind = structField.Type.Elem().Kind()
 	} else {
-		kind = fieldType.Type.Kind()
+		kind = structField.Type.Kind()
 	}
 
 	// Handle String case
@@ -265,7 +265,7 @@ func unmarshallID(node *Node, fieldValue reflect.Value, fieldType reflect.Struct
 
 	// Convert the numeric float to one of the supported ID numeric types
 	// (int[8,16,32,64] or uint[8,16,32,64])
-	idValue, err := handleNumeric(floatValue, fieldType.Type, fieldValue)
+	idValue, err := handleNumeric(floatValue, structField.Type, fieldValue)
 	if err != nil {
 		// We had a JSON float (numeric), but our field was not one of the
 		// allowed numeric types

--- a/request.go
+++ b/request.go
@@ -160,7 +160,8 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 		fieldValue := modelValue.Field(i)
 
-		args := strings.Split(tag, ",")
+		args := strings.Split(tag, annotationSeparator)
+
 		if len(args) < 1 {
 			er = ErrBadJSONAPIStructTag
 			break

--- a/request.go
+++ b/request.go
@@ -151,7 +151,7 @@ func unmarshalNode(data *Node, model reflect.Value, included *map[string]*Node) 
 
 	for i := 0; i < modelValue.NumField(); i++ {
 		fieldType := modelType.Field(i)
-		tag := fieldType.Tag.Get("jsonapi")
+		tag := fieldType.Tag.Get(annotationJSONAPI)
 		if tag == "" {
 			continue
 		}

--- a/request_test.go
+++ b/request_test.go
@@ -218,13 +218,12 @@ func TestUnmarshalToStructNullStringID(t *testing.T) {
 			"type": "null-string-id",
 			"id":   "314",
 			"attributes": map[string]interface{}{
-				"periodic":        false,
-				"name":            "Pi",
-				"value":           3.1415926535897932,
-				"decimal":         3,
-				"fractional":      1415926535897932,
-				"computed_at":     1615734000,
-				"computed_at_iso": "2021-03-14T15:00:00Z",
+				"periodic":    false,
+				"name":        "Pi",
+				"value":       3.1415926535897932,
+				"decimal":     3,
+				"fractional":  1415926535897932,
+				"computed_at": "2021-03-14T15:00:00Z",
 			},
 		},
 	}
@@ -257,9 +256,6 @@ func TestUnmarshalToStructNullStringID(t *testing.T) {
 		t.Fatalf("Error unmarshalling to sql.NullInt64")
 	}
 	if !pi.ComputedAt.Time.Equal(time.Unix(1615734000, 0)) {
-		t.Fatalf("Error unmarshalling to sql.NullTime")
-	}
-	if !pi.ComputedAtISO.Time.Equal(time.Unix(1615734000, 0)) {
 		t.Fatalf("Error unmarshalling to sql.NullTime")
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -212,6 +212,124 @@ func TestUnmarshalToStructWithPointerAttr_BadType_IntSlice(t *testing.T) {
 	}
 }
 
+func TestUnmarshalToStructNullStringID(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "null-string-id",
+			"id":   "314",
+			"attributes": map[string]interface{}{
+				"periodic":        false,
+				"name":            "Pi",
+				"value":           3.1415926535897932,
+				"decimal":         3,
+				"fractional":      1415926535897932,
+				"computed_at":     1615734000,
+				"computed_at_iso": "2021-03-14T15:00:00Z",
+			},
+		},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pi := new(NullStringID)
+	if err = UnmarshalPayload(bytes.NewReader(payload), pi); err != nil {
+		t.Fatal(err)
+	}
+
+	if pi.ID.String != "314" {
+		t.Fatalf("Error unmarshalling to sql.NullString")
+	}
+	if pi.Name.String != "Pi" {
+		t.Fatalf("Error unmarshalling to sql.NullString")
+	}
+	if pi.Periodic.Bool {
+		t.Fatalf("Error unmarshalling to sql.NullBool")
+	}
+	if pi.Value.Float64 != 3.1415926535897932 {
+		t.Fatalf("Error unmarshalling to sql.NullFloat64")
+	}
+	if pi.Decimal.Int32 != 3 {
+		t.Fatalf("Error unmarshalling to sql.NullInt32")
+	}
+	if pi.Fractional.Int64 != 1415926535897932 {
+		t.Fatalf("Error unmarshalling to sql.NullInt64")
+	}
+	if !pi.ComputedAt.Time.Equal(time.Unix(1615734000, 0)) {
+		t.Fatalf("Error unmarshalling to sql.NullTime")
+	}
+	if !pi.ComputedAtISO.Time.Equal(time.Unix(1615734000, 0)) {
+		t.Fatalf("Error unmarshalling to sql.NullTime")
+	}
+}
+
+func TestUnmarshalToStructNullInt32ID(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "null-int32-id",
+			"id":   "123",
+		},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i32 := new(NullInt32ID)
+	if err = UnmarshalPayload(bytes.NewReader(payload), i32); err != nil {
+		t.Fatal(err)
+	}
+
+	if i32.ID.Int32 != 123 {
+		t.Fatalf("Error unmarshalling to sql.NullInt32")
+	}
+}
+
+func TestUnmarshalToStructNullInt64ID(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "null-int64-id",
+			"id":   "456",
+		},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i64 := new(NullInt64ID)
+	if err = UnmarshalPayload(bytes.NewReader(payload), i64); err != nil {
+		t.Fatal(err)
+	}
+
+	if i64.ID.Int64 != 456 {
+		t.Fatalf("Error unmarshalling to sql.NullInt64")
+	}
+}
+
+func TestUnmarshalToStructNullFloat64ID(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "null-float64-id",
+			"id":   "789",
+		},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f64 := new(NullFloat64ID)
+	if err = UnmarshalPayload(bytes.NewReader(payload), f64); err != nil {
+		t.Fatal(err)
+	}
+
+	if f64.ID.Float64 != 789 {
+		t.Fatalf("Error unmarshalling to sql.NullFloat64")
+	}
+}
+
 func TestStringPointerField(t *testing.T) {
 	// Build Book payload
 	description := "Hello World!"
@@ -389,6 +507,32 @@ func TestUnmarshalParsesISO8601TimePointer(t *testing.T) {
 	expected := time.Date(2016, 8, 17, 8, 27, 12, 0, time.UTC)
 
 	if !out.Next.Equal(expected) {
+		t.Fatal("Parsing the ISO8601 timestamp failed")
+	}
+}
+
+func TestUnmarshalParsesISO8601NullTime(t *testing.T) {
+	payload := &OnePayload{
+		Data: &Node{
+			Type: "timestamps",
+			Attributes: map[string]interface{}{
+				"null": "2016-08-17T08:27:12Z",
+			},
+		},
+	}
+
+	in := bytes.NewBuffer(nil)
+	json.NewEncoder(in).Encode(payload)
+
+	out := new(Timestamp)
+
+	if err := UnmarshalPayload(in, out); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := time.Date(2016, 8, 17, 8, 27, 12, 0, time.UTC)
+
+	if !out.Null.Time.Equal(expected) {
 		t.Fatal("Parsing the ISO8601 timestamp failed")
 	}
 }

--- a/response.go
+++ b/response.go
@@ -416,6 +416,33 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 			return node
 		}
 
+		// Deal with database/sql null types
+		if nBool, ok := fieldValue.Interface().(sql.NullBool); ok {
+			node.Attributes[args[1]] = nBool.Bool
+			break
+		}
+
+		if nStr, ok := fieldValue.Interface().(sql.NullString); ok {
+			node.Attributes[args[1]] = nStr.String
+			break
+		}
+
+		if nF64, ok := fieldValue.Interface().(sql.NullFloat64); ok {
+			node.Attributes[args[1]] = nF64.Float64
+			break
+		}
+
+		if nI32, ok := fieldValue.Interface().(sql.NullInt32); ok {
+			node.Attributes[args[1]] = nI32.Int32
+			break
+		}
+
+		if nI64, ok := fieldValue.Interface().(sql.NullInt64); ok {
+			node.Attributes[args[1]] = nI64.Int64
+			break
+		}
+
+		// Handle string and remaining types
 		if str, ok := fieldValue.Interface().(string); ok {
 			node.Attributes[args[1]] = str
 		} else {

--- a/response.go
+++ b/response.go
@@ -422,28 +422,48 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 		}
 
 		// Handle remaining sql.Null* types
-		if nBool, ok := fieldValue.Interface().(sql.NullBool); ok {
-			node.Attributes[args[1]] = nBool.Bool
+		if boo, ok := fieldValue.Interface().(sql.NullBool); ok {
+			if boo.Valid {
+				node.Attributes[args[1]] = boo.Bool
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if str, ok := fieldValue.Interface().(sql.NullString); ok {
-			node.Attributes[args[1]] = str.String
+			if str.Valid {
+				node.Attributes[args[1]] = str.String
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if f64, ok := fieldValue.Interface().(sql.NullFloat64); ok {
-			node.Attributes[args[1]] = f64.Float64
+			if f64.Valid {
+				node.Attributes[args[1]] = f64.Float64
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if i32, ok := fieldValue.Interface().(sql.NullInt32); ok {
-			node.Attributes[args[1]] = i32.Int32
+			if i32.Valid {
+				node.Attributes[args[1]] = i32.Int32
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if i64, ok := fieldValue.Interface().(sql.NullInt64); ok {
-			node.Attributes[args[1]] = i64.Int64
+			if i64.Valid {
+				node.Attributes[args[1]] = i64.Int64
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 

--- a/response.go
+++ b/response.go
@@ -309,18 +309,23 @@ func resolveNodeID(node *Node, fieldValue reflect.Value, fieldType reflect.Struc
 	case reflect.Uint64:
 		node.ID = strconv.FormatUint(v.Interface().(uint64), 10)
 	case reflect.Struct:
-		if nStr, ok := v.Interface().(sql.NullString); ok {
-			node.ID = nStr.String
+		if str, ok := v.Interface().(sql.NullString); ok {
+			node.ID = str.String
 			break
 		}
 
-		if nI32, ok := v.Interface().(sql.NullInt32); ok {
-			node.ID = strconv.FormatInt(int64(nI32.Int32), 10)
+		if i32, ok := v.Interface().(sql.NullInt32); ok {
+			node.ID = strconv.FormatInt(int64(i32.Int32), 10)
 			break
 		}
 
-		if nI64, ok := v.Interface().(sql.NullInt64); ok {
-			node.ID = strconv.FormatInt(nI64.Int64, 10)
+		if i64, ok := v.Interface().(sql.NullInt64); ok {
+			node.ID = strconv.FormatInt(i64.Int64, 10)
+			break
+		}
+
+		if f64, ok := v.Interface().(sql.NullFloat64); ok {
+			node.ID = strconv.FormatFloat(f64.Float64, 'f', -1, 64)
 			break
 		}
 

--- a/response.go
+++ b/response.go
@@ -19,7 +19,7 @@ var (
 	// ErrBadJSONAPIID is returned when the Struct JSON API annotated "id" field
 	// was not a valid numeric type.
 	ErrBadJSONAPIID = errors.New(
-		"id should be either string, int(8,16,32,64) or uint(8,16,32,64)")
+		"id should be either string, int(8,16,32,64), uint(8,16,32,64) or sql.Null(Int32, Int64, Float64)")
 	// ErrExpectedSlice is returned when a variable or argument was expected to
 	// be a slice of *Structs; MarshalMany will return this error when its
 	// interface{} argument is invalid.

--- a/response.go
+++ b/response.go
@@ -418,27 +418,67 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 
 		// Deal with database/sql null types
 		if nBool, ok := fieldValue.Interface().(sql.NullBool); ok {
-			node.Attributes[args[1]] = nBool.Bool
+			if !nBool.Valid && omitEmpty {
+				return node
+			}
+
+			if nBool.Valid {
+				node.Attributes[args[1]] = nBool.Bool
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if nStr, ok := fieldValue.Interface().(sql.NullString); ok {
-			node.Attributes[args[1]] = nStr.String
+			if !nStr.Valid && omitEmpty {
+				return node
+			}
+
+			if nStr.Valid {
+				node.Attributes[args[1]] = nStr.String
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if nF64, ok := fieldValue.Interface().(sql.NullFloat64); ok {
-			node.Attributes[args[1]] = nF64.Float64
+			if !nF64.Valid && omitEmpty {
+				return node
+			}
+
+			if nF64.Valid {
+				node.Attributes[args[1]] = nF64.Float64
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if nI32, ok := fieldValue.Interface().(sql.NullInt32); ok {
-			node.Attributes[args[1]] = nI32.Int32
+			if !nI32.Valid && omitEmpty {
+				return node
+			}
+
+			if nI32.Valid {
+				node.Attributes[args[1]] = nI32.Int32
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 
 		if nI64, ok := fieldValue.Interface().(sql.NullInt64); ok {
-			node.Attributes[args[1]] = nI64.Int64
+			if !nI64.Valid && omitEmpty {
+				return node
+			}
+
+			if nI64.Valid {
+				node.Attributes[args[1]] = nI64.Int64
+			} else {
+				node.Attributes[args[1]] = nil
+			}
 			break
 		}
 

--- a/response.go
+++ b/response.go
@@ -386,6 +386,27 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 				node.Attributes[args[1]] = t.Unix()
 			}
 		}
+	case reflect.TypeOf(sql.NullTime{}):
+		nt := fieldValue.Interface().(sql.NullTime)
+
+		// Time is NULL
+		if !nt.Valid {
+			if omitEmpty {
+				return node
+			}
+
+			node.Attributes[args[1]] = nil
+		} else {
+			if nt.Time.IsZero() && omitEmpty {
+				return node
+			}
+
+			if iso8601 {
+				node.Attributes[args[1]] = nt.Time.UTC().Format(iso8601TimeFormat)
+			} else {
+				node.Attributes[args[1]] = nt.Time.Unix()
+			}
+		}
 	default:
 		// Dealing with a fieldValue that is not a time
 		emptyValue := reflect.Zero(fieldValue.Type())

--- a/response.go
+++ b/response.go
@@ -418,72 +418,32 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 
 		// See if we need to omit this field
 		if omitEmpty && reflect.DeepEqual(fieldValue.Interface(), emptyValue.Interface()) {
-			return node
+			break
 		}
 
-		// Deal with database/sql null types
+		// Handle remaining sql.Null* types
 		if nBool, ok := fieldValue.Interface().(sql.NullBool); ok {
-			if !nBool.Valid && omitEmpty {
-				return node
-			}
-
-			if nBool.Valid {
-				node.Attributes[args[1]] = nBool.Bool
-			} else {
-				node.Attributes[args[1]] = nil
-			}
+			node.Attributes[args[1]] = nBool.Bool
 			break
 		}
 
-		if nStr, ok := fieldValue.Interface().(sql.NullString); ok {
-			if !nStr.Valid && omitEmpty {
-				return node
-			}
-
-			if nStr.Valid {
-				node.Attributes[args[1]] = nStr.String
-			} else {
-				node.Attributes[args[1]] = nil
-			}
+		if str, ok := fieldValue.Interface().(sql.NullString); ok {
+			node.Attributes[args[1]] = str.String
 			break
 		}
 
-		if nF64, ok := fieldValue.Interface().(sql.NullFloat64); ok {
-			if !nF64.Valid && omitEmpty {
-				return node
-			}
-
-			if nF64.Valid {
-				node.Attributes[args[1]] = nF64.Float64
-			} else {
-				node.Attributes[args[1]] = nil
-			}
+		if f64, ok := fieldValue.Interface().(sql.NullFloat64); ok {
+			node.Attributes[args[1]] = f64.Float64
 			break
 		}
 
-		if nI32, ok := fieldValue.Interface().(sql.NullInt32); ok {
-			if !nI32.Valid && omitEmpty {
-				return node
-			}
-
-			if nI32.Valid {
-				node.Attributes[args[1]] = nI32.Int32
-			} else {
-				node.Attributes[args[1]] = nil
-			}
+		if i32, ok := fieldValue.Interface().(sql.NullInt32); ok {
+			node.Attributes[args[1]] = i32.Int32
 			break
 		}
 
-		if nI64, ok := fieldValue.Interface().(sql.NullInt64); ok {
-			if !nI64.Valid && omitEmpty {
-				return node
-			}
-
-			if nI64.Valid {
-				node.Attributes[args[1]] = nI64.Int64
-			} else {
-				node.Attributes[args[1]] = nil
-			}
+		if i64, ok := fieldValue.Interface().(sql.NullInt64); ok {
+			node.Attributes[args[1]] = i64.Int64
 			break
 		}
 

--- a/response.go
+++ b/response.go
@@ -272,16 +272,16 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 	return node, nil
 }
 
-func resolveNodeID(node *Node, fieldValue reflect.Value, fieldType reflect.StructField) (*Node, error) {
+func resolveNodeID(node *Node, fieldValue reflect.Value, structField reflect.StructField) (*Node, error) {
 	v := fieldValue
 
 	// Deal with PTRS
 	var kind reflect.Kind
 	if fieldValue.Kind() == reflect.Ptr {
-		kind = fieldType.Type.Elem().Kind()
+		kind = structField.Type.Elem().Kind()
 		v = reflect.Indirect(fieldValue)
 	} else {
-		kind = fieldType.Type.Kind()
+		kind = structField.Type.Kind()
 	}
 
 	// Handle allowed types

--- a/response.go
+++ b/response.go
@@ -1,6 +1,7 @@
 package jsonapi
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -307,6 +308,23 @@ func resolveNodeID(node *Node, fieldValue reflect.Value, fieldType reflect.Struc
 		node.ID = strconv.FormatUint(uint64(v.Interface().(uint32)), 10)
 	case reflect.Uint64:
 		node.ID = strconv.FormatUint(v.Interface().(uint64), 10)
+	case reflect.Struct:
+		if nStr, ok := v.Interface().(sql.NullString); ok {
+			node.ID = nStr.String
+			break
+		}
+
+		if nI32, ok := v.Interface().(sql.NullInt32); ok {
+			node.ID = strconv.FormatInt(int64(nI32.Int32), 10)
+			break
+		}
+
+		if nI64, ok := v.Interface().(sql.NullInt64); ok {
+			node.ID = strconv.FormatInt(nI64.Int64, 10)
+			break
+		}
+
+		fallthrough
 	default:
 		// We had a JSON float (numeric), but our field was not one of the
 		// allowed numeric types

--- a/response.go
+++ b/response.go
@@ -174,7 +174,7 @@ func marshalMany(models []interface{}) (*ManyPayload, error) {
 // related records. This method will serialize a single struct
 // pointer into an embedded json response. In other words, there
 // will be no, "included", array in the json all relationships will
-// be serailized inline in the data.
+// be serialized inline in the data.
 //
 // However, in tests, you may want to construct payloads to post
 // to create methods that are embedded to most closely resemble

--- a/response.go
+++ b/response.go
@@ -397,7 +397,7 @@ func resolveNodeAttribute(node *Node, fieldValue reflect.Value, args []string) *
 
 			node.Attributes[args[1]] = nil
 		} else {
-			if nt.Time.IsZero() && omitEmpty {
+			if nt.Time.IsZero() {
 				return node
 			}
 

--- a/response.go
+++ b/response.go
@@ -215,7 +215,7 @@ func visitModelNode(model interface{}, included *map[string]*Node,
 		fieldValue := modelValue.Field(i)
 		fieldType := modelType.Field(i)
 
-		args := strings.Split(tag, annotationSeperator)
+		args := strings.Split(tag, annotationSeparator)
 
 		if len(args) < 1 {
 			er = ErrBadJSONAPIStructTag

--- a/response_test.go
+++ b/response_test.go
@@ -2,6 +2,7 @@ package jsonapi
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"reflect"
 	"sort"
@@ -116,7 +117,7 @@ func TestWithoutOmitsEmptyAnnotationOnRelation(t *testing.T) {
 	}
 	relationships := jsonData["data"].(map[string]interface{})["relationships"].(map[string]interface{})
 
-	// Verifiy the "posts" relation was an empty array
+	// Verify the "posts" relation was an empty array
 	posts, ok := relationships["posts"]
 	if !ok {
 		t.Fatal("Was expecting the data.relationships.posts key/value to have been present")
@@ -137,7 +138,7 @@ func TestWithoutOmitsEmptyAnnotationOnRelation(t *testing.T) {
 		t.Fatal("Was expecting the data.relationships.posts.data value to have been an empty array []")
 	}
 
-	// Verifiy the "current_post" was a null
+	// Verify the "current_post" was a null
 	currentPost, postExists := relationships["current_post"]
 	if !postExists {
 		t.Fatal("Was expecting the data.relationships.current_post key/value to have NOT been omitted")
@@ -522,6 +523,314 @@ func TestMarshalISO8601TimePointer(t *testing.T) {
 
 	if data.Attributes["next"] != "2016-08-17T08:27:12Z" {
 		t.Fatal("Next was not serialised into ISO8601 correctly")
+	}
+}
+
+func TestMarshalISO8601NullTime(t *testing.T) {
+	testModel := &Timestamp{
+		ID: 5,
+		Null: sql.NullTime{
+			Time:  time.Date(2016, 8, 17, 8, 27, 12, 23849, time.UTC),
+			Valid: true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, testModel); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.Attributes == nil {
+		t.Fatalf("Expected attributes")
+	}
+
+	if data.Attributes["null"] != "2016-08-17T08:27:12Z" {
+		t.Fatal("Null was not serialised into ISO8601 correctly")
+	}
+}
+
+func TestMarshalISO8601NullTime_Zero(t *testing.T) {
+	testModel := &Timestamp{
+		ID:   5,
+		Null: sql.NullTime{Valid: true},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, testModel); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.NewDecoder(out).Decode(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.Attributes == nil {
+		t.Fatal("Expected attributes")
+	}
+
+	if data.Attributes["null"] != nil {
+		t.Fatalf("Null should not have been serialised")
+	}
+}
+
+func TestMarshalStructNullStringID_Zero_Invalid(t *testing.T) {
+	pi := new(NullStringID)
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, pi); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonData map[string]interface{}
+
+	if err := json.Unmarshal(out.Bytes(), &jsonData); err != nil {
+		t.Fatal(err)
+	}
+	data := jsonData["data"].(map[string]interface{})
+
+	if data["type"] != "null-string-id" {
+		t.Fatalf("Error marshalling type")
+	}
+
+	if _, ok := data["attributes"]; ok {
+		t.Fatal("Was expecting data.attributes to be omitted")
+	}
+}
+
+func TestMarshalStructNullStringID_Zero_Valid(t *testing.T) {
+	pi := &NullStringID{
+		ID:            sql.NullString{Valid: true},
+		Periodic:      sql.NullBool{Valid: true},
+		Name:          sql.NullString{Valid: true},
+		Value:         sql.NullFloat64{Valid: true},
+		Decimal:       sql.NullInt32{Valid: true},
+		Fractional:    sql.NullInt64{Valid: true},
+		ComputedAt:    sql.NullTime{Valid: true},
+		ComputedAtISO: sql.NullTime{Valid: true},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, pi); err != nil {
+		t.Fatal(err)
+	}
+
+	var jsonData map[string]interface{}
+
+	if err := json.Unmarshal(out.Bytes(), &jsonData); err != nil {
+		t.Fatal(err)
+	}
+	data := jsonData["data"].(map[string]interface{})
+
+	if _, ok := data["id"]; ok {
+		t.Fatal("Was expecting data.id to be omitted")
+	}
+
+	if data["type"] != "null-string-id" {
+		t.Fatalf("Error marshalling type")
+	}
+
+	attributes := data["attributes"].(map[string]interface{})
+
+	if attributes["periodic"] != false {
+		t.Fatalf("Error marshalling to sql.NullBool: %v", attributes["periodic"])
+	}
+
+	if attributes["name"] != "" {
+		t.Fatal("Error marshalling to sql.NullString")
+	}
+
+	if attributes["value"] != 0.0 {
+		t.Fatal("Error marshalling to sql.NullFloat64")
+	}
+
+	if attributes["decimal"] != 0.0 {
+		t.Fatalf("Error marshalling to sql.NullInt32")
+	}
+
+	if attributes["fractional"] != 0.0 {
+		t.Fatalf("Error marshalling to sql.NullInt64")
+	}
+
+	if _, ok := attributes["computed_at"]; ok {
+		t.Fatal("Was expecting data.attributes.computed_at to be omitted")
+	}
+
+	if _, ok := attributes["computed_at_iso"]; ok {
+		t.Fatal("Was expecting data.attributes.computed_at_iso to be omitted")
+	}
+}
+
+func TestMarshalStructNullStringID(t *testing.T) {
+	pi := &NullStringID{
+		ID: sql.NullString{
+			String: "314",
+			Valid:  true,
+		},
+		Periodic: sql.NullBool{
+			Bool:  false,
+			Valid: true,
+		},
+		Name: sql.NullString{
+			String: "Pi",
+			Valid:  true,
+		},
+		Value: sql.NullFloat64{
+			Float64: 3.1415926535897932,
+			Valid:   true,
+		},
+		Decimal: sql.NullInt32{
+			Int32: 3,
+			Valid: true,
+		},
+		Fractional: sql.NullInt64{
+			Int64: 1415926535897932,
+			Valid: true,
+		},
+		ComputedAt: sql.NullTime{
+			Time:  time.Date(2021, 3, 14, 15, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+		ComputedAtISO: sql.NullTime{
+			Time:  time.Date(2021, 3, 14, 15, 0, 0, 0, time.UTC),
+			Valid: true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, pi); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.Unmarshal(out.Bytes(), resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.ID != "314" {
+		t.Fatal("Error marshalling id")
+	}
+
+	if data.Type != "null-string-id" {
+		t.Fatal("Error marshalling type")
+	}
+
+	if data.Attributes["periodic"] != false {
+		t.Fatal("Error marshalling to sql.NullBool")
+	}
+
+	if data.Attributes["name"] != "Pi" {
+		t.Fatal("Error marshalling to sql.NullString")
+	}
+
+	if data.Attributes["value"] != 3.1415926535897932 {
+		t.Fatal("Error marshalling to sql.NullFloat64")
+	}
+
+	if data.Attributes["decimal"] != 3.0 {
+		t.Fatalf("Error marshalling to sql.NullInt32")
+	}
+
+	if data.Attributes["computed_at_iso"] != "2021-03-14T15:00:00Z" {
+		t.Fatalf("Error marshalling to sql.NullTime")
+	}
+}
+
+func TestMarshalStructNullInt32ID(t *testing.T) {
+	i32 := &NullInt32ID{
+		ID: sql.NullInt32{
+			Int32: 123,
+			Valid: true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, i32); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.Unmarshal(out.Bytes(), resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.ID != "123" {
+		t.Fatalf("Error marshalling id")
+	}
+
+	if data.Type != "null-int32-id" {
+		t.Fatal("Error marshalling type")
+	}
+}
+
+func TestMarshalStructNullInt64ID(t *testing.T) {
+	i32 := &NullInt64ID{
+		ID: sql.NullInt64{
+			Int64: 456,
+			Valid: true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, i32); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.Unmarshal(out.Bytes(), resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.ID != "456" {
+		t.Fatalf("Error marshalling id")
+	}
+
+	if data.Type != "null-int64-id" {
+		t.Fatal("Error marshalling type")
+	}
+}
+
+func TestMarshalStructNullFloat64ID(t *testing.T) {
+	i32 := &NullFloat64ID{
+		ID: sql.NullFloat64{
+			Float64: 12345678.12345678,
+			Valid:   true,
+		},
+	}
+
+	out := bytes.NewBuffer(nil)
+	if err := MarshalPayload(out, i32); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := new(OnePayload)
+	if err := json.Unmarshal(out.Bytes(), resp); err != nil {
+		t.Fatal(err)
+	}
+
+	data := resp.Data
+
+	if data.ID != "12345678.12345678" {
+		t.Fatal("Error marshalling id")
+	}
+
+	if data.Type != "null-float64-id" {
+		t.Fatal("Error marshalling type")
 	}
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -609,14 +609,13 @@ func TestMarshalStructNullStringID_Zero_Invalid(t *testing.T) {
 
 func TestMarshalStructNullStringID_Zero_Valid(t *testing.T) {
 	pi := &NullStringID{
-		ID:            sql.NullString{Valid: true},
-		Periodic:      sql.NullBool{Valid: true},
-		Name:          sql.NullString{Valid: true},
-		Value:         sql.NullFloat64{Valid: true},
-		Decimal:       sql.NullInt32{Valid: true},
-		Fractional:    sql.NullInt64{Valid: true},
-		ComputedAt:    sql.NullTime{Valid: true},
-		ComputedAtISO: sql.NullTime{Valid: true},
+		ID:         sql.NullString{Valid: true},
+		Periodic:   sql.NullBool{Valid: true},
+		Name:       sql.NullString{Valid: true},
+		Value:      sql.NullFloat64{Valid: true},
+		Decimal:    sql.NullInt32{Valid: true},
+		Fractional: sql.NullInt64{Valid: true},
+		ComputedAt: sql.NullTime{Valid: true},
 	}
 
 	out := bytes.NewBuffer(nil)
@@ -664,10 +663,6 @@ func TestMarshalStructNullStringID_Zero_Valid(t *testing.T) {
 	if _, ok := attributes["computed_at"]; ok {
 		t.Fatal("Was expecting data.attributes.computed_at to be omitted")
 	}
-
-	if _, ok := attributes["computed_at_iso"]; ok {
-		t.Fatal("Was expecting data.attributes.computed_at_iso to be omitted")
-	}
 }
 
 func TestMarshalStructNullStringID(t *testing.T) {
@@ -697,10 +692,6 @@ func TestMarshalStructNullStringID(t *testing.T) {
 			Valid: true,
 		},
 		ComputedAt: sql.NullTime{
-			Time:  time.Date(2021, 3, 14, 15, 0, 0, 0, time.UTC),
-			Valid: true,
-		},
-		ComputedAtISO: sql.NullTime{
 			Time:  time.Date(2021, 3, 14, 15, 0, 0, 0, time.UTC),
 			Valid: true,
 		},
@@ -742,7 +733,7 @@ func TestMarshalStructNullStringID(t *testing.T) {
 		t.Fatalf("Error marshalling to sql.NullInt32")
 	}
 
-	if data.Attributes["computed_at_iso"] != "2021-03-14T15:00:00Z" {
+	if data.Attributes["computed_at"] != "2021-03-14T15:00:00Z" {
 		t.Fatalf("Error marshalling to sql.NullTime")
 	}
 }


### PR DESCRIPTION
## Description
This pull request addresses issue https://github.com/google/jsonapi/issues/122, which aims to add support for `database/sql` null types.

I mainly want to start a discussion about the implementation, since there's definitely room for change/improvement.

Also, while pushing my changes, I realised from the TravisCI results that Go versions prior to 1.13 don't have support for `database/sql` null types. Would bumping the minimum Go version to 1.13 be a deal breaker?

## Task items:
- **Response (Marshall):**
  - [X] Split the response `visitModelNode()` function logic, to be more manageable/readable;
  - [X] Move the node ID resolution logic into `resolveNodeID()`;
    - [X] Add support for IDs of the type: `sql.NullString`, `sql.NullInt32`, `sql.NullInt64` and `sql.NullFloat64`
  - [X] Move the node attribute resolution logic into `resolveNodeAttribute()`;
    - [X] Add support for attributes of the type: `sql.NullTime`, `sql.NullBool`, `sql.NullString`, `sql.NullFloat64`, `sql.NullInt32` and `sql.NullInt64`
  - [X] Move the node relation resolution logic into `resolveNodeRelation()`;
- **Request (Unmarshall):**
  - [X] Split the request `unmarshalNode()` function logic, to be more manageable/readable;
  - [X] Move the node ID resolution into `unmarshallID()`;
    - [X] Add support for IDs of the type: `sql.NullString`, `sql.NullInt32`, `sql.NullInt64` and `sql.NullFloat64`
  - [X] Add support for attributes of the type: `sql.NullTime`, `sql.NullBool`, `sql.NullString`, `sql.NullFloat64`, `sql.NullInt32` and `sql.NullInt64`
  - [X] Move the node relation resolution logic into `unmarshallRelation()`;
- [X] Update/increase test coverage;
