### PR TITLE
fixes response content-type in example

### DIFF
--- a/examples/handler.go
+++ b/examples/handler.go
@@ -53,8 +53,8 @@ func (h *ExampleHandler) createBlog(w http.ResponseWriter, r *http.Request) {
 
 	// ...do stuff with your blog...
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set(headerContentType, jsonapi.MediaType)
+	w.WriteHeader(http.StatusCreated)
 
 	if err := jsonapiRuntime.MarshalPayload(w, blog); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -68,8 +68,9 @@ func (h *ExampleHandler) echoBlogs(w http.ResponseWriter, r *http.Request) {
 	// but, for now
 	blogs := fixtureBlogsList()
 
-	w.WriteHeader(http.StatusOK)
 	w.Header().Set(headerContentType, jsonapi.MediaType)
+	w.WriteHeader(http.StatusOK)
+
 	if err := jsonapiRuntime.MarshalPayload(w, blogs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -90,9 +91,9 @@ func (h *ExampleHandler) showBlog(w http.ResponseWriter, r *http.Request) {
 
 	// but, for now
 	blog := fixtureBlogCreate(intID)
+	w.Header().Set(headerContentType, jsonapi.MediaType)
 	w.WriteHeader(http.StatusOK)
 
-	w.Header().Set(headerContentType, jsonapi.MediaType)
 	if err := jsonapiRuntime.MarshalPayload(w, blog); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/examples/handler_test.go
+++ b/examples/handler_test.go
@@ -27,6 +27,10 @@ func TestExampleHandler_post(t *testing.T) {
 	if e, a := http.StatusCreated, rr.Code; e != a {
 		t.Fatalf("Expected a status of %d, got %d", e, a)
 	}
+
+	if e, a := jsonapi.MediaType, rr.Result().Header.Get(headerContentType); e != a {
+		t.Fatalf("Expected a Content-Type of %s, got %s", e, a)
+	}
 }
 
 func TestExampleHandler_put(t *testing.T) {
@@ -51,6 +55,10 @@ func TestExampleHandler_put(t *testing.T) {
 	if e, a := http.StatusOK, rr.Code; e != a {
 		t.Fatalf("Expected a status of %d, got %d", e, a)
 	}
+
+	if e, a := jsonapi.MediaType, rr.Result().Header.Get(headerContentType); e != a {
+		t.Fatalf("Expected a Content-Type of %s, got %s", e, a)
+	}
 }
 
 func TestExampleHandler_get_show(t *testing.T) {
@@ -67,6 +75,10 @@ func TestExampleHandler_get_show(t *testing.T) {
 	if e, a := http.StatusOK, rr.Code; e != a {
 		t.Fatalf("Expected a status of %d, got %d", e, a)
 	}
+
+	if e, a := jsonapi.MediaType, rr.Result().Header.Get(headerContentType); e != a {
+		t.Fatalf("Expected a Content-Type of %s, got %s", e, a)
+	}
 }
 
 func TestExampleHandler_get_list(t *testing.T) {
@@ -82,6 +94,10 @@ func TestExampleHandler_get_list(t *testing.T) {
 
 	if e, a := http.StatusOK, rr.Code; e != a {
 		t.Fatalf("Expected a status of %d, got %d", e, a)
+	}
+
+	if e, a := jsonapi.MediaType, rr.Result().Header.Get(headerContentType); e != a {
+		t.Fatalf("Expected a Content-Type of %s, got %s", e, a)
 	}
 }
 


### PR DESCRIPTION
I noticed while coping the example and playing around, that I was receiving the wrong content-type in my responses.

I hope this little fix will ensure others don't get caught in the same trap I was in.