### PR TITLE
Support rel, title, type, and hreflang link target attributes

### DIFF
--- a/models_test.go
+++ b/models_test.go
@@ -94,6 +94,13 @@ func (b *Blog) JSONAPILinks() *Links {
 				},
 			},
 		},
+		"frenchTranslation": Link{
+			Href:     fmt.Sprintf("https://example.com/fr-fr/blogs/%d", b.ID),
+			Rel:      "alternate",
+			Title:    b.Title,
+			Type:     "text/html",
+			HrefLang: "fr-fr",
+		},
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -87,8 +87,12 @@ func (l *Links) validate() (err error) {
 
 // Link is used to represent a member of the `links` object.
 type Link struct {
-	Href string `json:"href"`
-	Meta Meta   `json:"meta,omitempty"`
+	Href     string `json:"href"`
+	Rel      string `json:"rel,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Type     string `json:"type,omitempty"`
+	HrefLang string `json:"hreflang,omitempty"`
+	Meta     Meta   `json:"meta,omitempty"`
 }
 
 // Linkable is used to include document links in response data

--- a/response_test.go
+++ b/response_test.go
@@ -649,6 +649,63 @@ func TestSupportsLinkable(t *testing.T) {
 			t.Fatalf("Exepected value at '%s' to be a numeric (float64)", k)
 		}
 	}
+
+	translation, hasTranslation := links["frenchTranslation"]
+	if !hasTranslation {
+		t.Fatal("expect 'frenchTranslation' to be present")
+	}
+	translationMap, isMap := translation.(map[string]interface{})
+	if !isMap {
+		t.Fatal("Expected 'frenchTranslation' to contain a map")
+	}
+
+	alternateHref, hasHref := translationMap["href"]
+	if !hasHref {
+		t.Fatal("Expect 'alternate' to contain an 'href' key/value")
+	}
+	if _, isString := alternateHref.(string); !isString {
+		t.Fatal("Expected 'href' to contain a string")
+	}
+
+	alternateRel, hasRel := translationMap["rel"]
+	if !hasRel {
+		t.Fatal("Expect 'alternate' to contain an 'rel' key/value")
+	}
+	if str, isString := alternateRel.(string); !isString {
+		t.Fatal("Expected 'rel' to contain a string")
+	} else if str != "alternate" {
+		t.Fatal("Expected the 'rel' value to be 'alternate'")
+	}
+
+	alternateTitle, hasTitle := translationMap["title"]
+	if !hasTitle {
+		t.Fatal("Expect 'alternate' to contain an 'title' key/value")
+	}
+	if str, isString := alternateTitle.(string); !isString {
+		t.Fatal("Expected 'title' to contain a string")
+	} else if str != "Title 1" {
+		t.Fatal("Expected the 'title' value to be 'Title 1'")
+	}
+
+	alternateType, hasType := translationMap["type"]
+	if !hasType {
+		t.Fatal("Expect 'alternate' to contain an 'type' key/value")
+	}
+	if str, isString := alternateType.(string); !isString {
+		t.Fatal("Expected 'type' to contain a string")
+	} else if str != "text/html" {
+		t.Fatal("Expected the 'type' value to be 'text/html'")
+	}
+
+	alternateHrefLang, hasHrefLang := translationMap["hreflang"]
+	if !hasHrefLang {
+		t.Fatal("Expect 'alternate' to contain an 'hreflang' key/value")
+	}
+	if str, isString := alternateHrefLang.(string); !isString {
+		t.Fatal("Expected 'hreflang' to contain a string")
+	} else if str != "fr-fr" {
+		t.Fatal("Expected the 'hreflang' value to be 'fr-fr'")
+	}
 }
 
 func TestInvalidLinkable(t *testing.T) {


### PR DESCRIPTION
Version 1.1 of the spec supports new, optional link target attributes: `rel`, `title`, `type` and `hreflang`. Each of these are simple string values. I chose not to implement `describedby` because it can be a nested link (and I don't need it :sweat_smile: ).