### PR TITLE
Omit nodes without attributes or relationships from included list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /examples/examples
+.idea/

--- a/response.go
+++ b/response.go
@@ -51,17 +51,16 @@ var (
 // Many Example: you could pass it, w, your http.ResponseWriter, and, models, a
 // slice of Blog struct instance pointers to be written to the response body:
 //
-//	 func ListBlogs(w http.ResponseWriter, r *http.Request) {
-//     blogs := []*Blog{}
+//		 func ListBlogs(w http.ResponseWriter, r *http.Request) {
+//	    blogs := []*Blog{}
 //
-//		 w.Header().Set("Content-Type", jsonapi.MediaType)
-//		 w.WriteHeader(http.StatusOK)
+//			 w.Header().Set("Content-Type", jsonapi.MediaType)
+//			 w.WriteHeader(http.StatusOK)
 //
-//		 if err := jsonapi.MarshalPayload(w, blogs); err != nil {
-//			 http.Error(w, err.Error(), http.StatusInternalServerError)
+//			 if err := jsonapi.MarshalPayload(w, blogs); err != nil {
+//				 http.Error(w, err.Error(), http.StatusInternalServerError)
+//			 }
 //		 }
-//	 }
-//
 func MarshalPayload(w io.Writer, models interface{}) error {
 	payload, err := Marshal(models)
 	if err != nil {
@@ -514,15 +513,19 @@ func appendIncluded(m *map[string]*Node, nodes ...*Node) {
 
 func nodeMapValues(m *map[string]*Node) []*Node {
 	mp := *m
-	nodes := make([]*Node, len(mp))
+	nodes := make([]*Node, 0)
 
-	i := 0
 	for _, n := range mp {
-		nodes[i] = n
-		i++
+		if !isNodeEmpty(n) {
+			nodes = append(nodes, n)
+		}
 	}
 
 	return nodes
+}
+
+func isNodeEmpty(n *Node) bool {
+	return (n.Attributes == nil || len(n.Attributes) == 0) && (n.Relationships == nil || len(n.Relationships) == 0)
 }
 
 func convertToSliceInterface(i *interface{}) ([]interface{}, error) {


### PR DESCRIPTION
Current implementation keeps "empty" records in the "included" list. Most commonly happens as an unwanted side effect when the client wants the ID value of the related resource only, but not the document itself. This rather complicates client-side which needs to be aware of possibly receiving records it never requested first place.

Fixes #138 